### PR TITLE
Bugfix: Extract parameter not working with multiple Puma components.

### DIFF
--- a/PumaGrasshopper/AttributeParameter.cs
+++ b/PumaGrasshopper/AttributeParameter.cs
@@ -93,6 +93,13 @@ namespace PumaGrasshopper.AttributeParameter
             return base.Read(reader);
         }
 
+        protected void RefreshRpk()
+        {
+            var pumaAttributes = (GH_ComponentAttributes)Attributes.GetTopLevel;
+            ComponentPuma puma = (ComponentPuma)pumaAttributes.Owner;
+            puma.RefreshRpk();
+        }
+
         protected void DisplayExtractedParam(IGH_Param param)
         {
             param.CreateAttributes();
@@ -139,6 +146,8 @@ namespace PumaGrasshopper.AttributeParameter
         private GH_Structure<GH_Boolean> GetData()
         {
             if (PersistentDataCount > 0) return PersistentData;
+
+            RefreshRpk();
 
             if (mExpectsArray)
             {
@@ -207,7 +216,9 @@ namespace PumaGrasshopper.AttributeParameter
         {
             if (PersistentDataCount > 0) return PersistentData;
 
-            if(mExpectsArray)
+            RefreshRpk();
+
+            if (mExpectsArray)
             {
                 List<List<double>> defaultValues = PRTWrapper.GetDefaultValuesNumberArray(Name);
                 if (defaultValues != null)
@@ -281,6 +292,8 @@ namespace PumaGrasshopper.AttributeParameter
         private GH_Structure<GH_String> GetData()
         {
             if (PersistentDataCount > 0) return PersistentData;
+
+            RefreshRpk();
 
             if (mExpectsArray)
             {
@@ -365,6 +378,8 @@ namespace PumaGrasshopper.AttributeParameter
         private GH_Structure<GH_Colour> GetData()
         {
             if (PersistentDataCount > 0) return PersistentData;
+
+            RefreshRpk();
 
             List<string> defaultValues = PRTWrapper.GetDefaultValuesText(Name);
             if (defaultValues != null)

--- a/PumaGrasshopper/ComponentPuma.cs
+++ b/PumaGrasshopper/ComponentPuma.cs
@@ -249,6 +249,15 @@ namespace PumaGrasshopper
             return result;
         }
 
+        public void RefreshRpk()
+        {
+            if (string.Compare(mCurrentRPK.path, PRTWrapper.GetPackagePath())
+                != 0)
+            {
+                ExpireSolution(true);
+            }
+        }
+
         private bool SetRulePackage(RulePackage rulePackage)
         {
             var errorMsg = new StringWrapper();
@@ -264,7 +273,11 @@ namespace PumaGrasshopper
 
         private bool CheckAndUpdateRulePackage(RulePackage potentiallyNewRulePackage)
         {
-            if (mCurrentRPK == null || !mCurrentRPK.IsSame(potentiallyNewRulePackage))
+            string currentPrtRpk = PRTWrapper.GetPackagePath();
+
+            if (mCurrentRPK == null
+                || !mCurrentRPK.IsSame(potentiallyNewRulePackage)
+                || string.Compare(potentiallyNewRulePackage.path, currentPrtRpk) != 0)
             {
                 mCurrentRPK = potentiallyNewRulePackage;
                 if (!SetRulePackage(mCurrentRPK))

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -50,6 +50,9 @@ namespace PumaGrasshopper
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern void SetPackage(string rpk_path, [In, Out] IntPtr errorMsg);
 
+        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        public static extern bool GetPackagePath([In, Out] IntPtr pRpk);
+
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern bool AddInitialMesh([In]IntPtr pMesh);
 
@@ -149,6 +152,23 @@ namespace PumaGrasshopper
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern bool GetDefaultValuesTextArray(string key, [In, Out] IntPtr pTexts, [In, Out] IntPtr pSizes);
+
+
+        public static string GetPackagePath()
+        {
+            string currentRpk = null;
+
+            StringWrapper rpk = new StringWrapper();
+            var rpkPtr = rpk.NonConstPointer;
+            bool success = GetPackagePath(rpkPtr);
+            if(success)
+            {
+                currentRpk = rpk.ToString();
+            }
+            rpk.Dispose();
+
+            return currentRpk;
+        }
 
         public static bool AddMesh(List<Mesh> meshes)
         {

--- a/PumaRhino/ModelGenerator.cpp
+++ b/PumaRhino/ModelGenerator.cpp
@@ -176,6 +176,8 @@ ModelGenerator::ModelGenerator() {
 }
 
 void ModelGenerator::updateRuleFiles(const std::wstring& rulePkg) {
+	mCurrentRPK = rulePkg;
+
 	try {
 		const ResolveMap::ResolveMapCache::LookupResult lookup = PRTContext::get()->getResolveMap(rulePkg);
 		if (lookup.second == ResolveMap::ResolveMapCache::CacheStatus::HIT && rulePkg == mRulePkg) {

--- a/PumaRhino/ModelGenerator.h
+++ b/PumaRhino/ModelGenerator.h
@@ -59,6 +59,10 @@ public:
 		return mDefaultValuesMap;
 	};
 
+	const std::wstring getPackagePath() const {
+		return mCurrentRPK;
+	}
+
 	bool getDefaultValuesBoolean(const std::wstring& key, ON_SimpleArray<int>* pValues);
 	bool getDefaultValuesNumber(const std::wstring& key, ON_SimpleArray<double>* pValues);
 	bool getDefaultValuesText(const std::wstring& key, ON_ClassArray<ON_wString>* pTexts);
@@ -86,6 +90,7 @@ private:
 	std::wstring mStartRule = L"default$Lot";
 	int32_t mSeed = 0;
 	std::wstring mShapeName = L"Lot";
+	std::wstring mCurrentRPK;
 
 	bool createInitialShapes(const std::vector<RawInitialShape>& rawInitialShapes,
 	                         const std::vector<pcu::ShapeAttributes>& shapeAttributes,

--- a/PumaRhino/PumaGrasshopperAPI.cpp
+++ b/PumaRhino/PumaGrasshopperAPI.cpp
@@ -72,6 +72,9 @@ RHINOPRT_API void SetPackage(const wchar_t* rpk_path, ON_wString* errorMsg) {
 }
 
 RHINOPRT_API bool GetPackagePath(ON_wString* pRpk) {
+	if (pRpk == nullptr)
+		return false;
+
 	const std::wstring rpk = RhinoPRT::get().GetRPKPath();
 	if (rpk.empty())
 		return false;

--- a/PumaRhino/PumaGrasshopperAPI.cpp
+++ b/PumaRhino/PumaGrasshopperAPI.cpp
@@ -71,6 +71,15 @@ RHINOPRT_API void SetPackage(const wchar_t* rpk_path, ON_wString* errorMsg) {
 	}
 }
 
+RHINOPRT_API bool GetPackagePath(ON_wString* pRpk) {
+	const std::wstring rpk = RhinoPRT::get().GetRPKPath();
+	if (rpk.empty())
+		return false;
+
+	*pRpk += rpk.c_str();
+	return true;
+}
+
 inline RHINOPRT_API bool AddInitialMesh(ON_SimpleArray<const ON_Mesh*>* pMesh) {
 	if (pMesh == nullptr)
 		return false;

--- a/PumaRhino/RhinoPRT.cpp
+++ b/PumaRhino/RhinoPRT.cpp
@@ -68,7 +68,7 @@ void RhinoPRTAPI::SetRPKPath(const std::wstring& rpkPath) {
 
 const std::wstring RhinoPRTAPI::GetRPKPath() const {
 	if (!mModelGenerator)
-		return L"";
+		return {};
 
 	return mModelGenerator->getPackagePath();
 }

--- a/PumaRhino/RhinoPRT.cpp
+++ b/PumaRhino/RhinoPRT.cpp
@@ -66,6 +66,13 @@ void RhinoPRTAPI::SetRPKPath(const std::wstring& rpkPath) {
 	mModelGenerator->updateRuleFiles(rpkPath); // might throw !
 }
 
+const std::wstring RhinoPRTAPI::GetRPKPath() const {
+	if (!mModelGenerator)
+		return L"";
+
+	return mModelGenerator->getPackagePath();
+}
+
 void RhinoPRTAPI::SetInitialShapes(const std::vector<RawInitialShape>& shapes) {
 
 	// get the shape attributes data from ModelGenerator

--- a/PumaRhino/RhinoPRT.h
+++ b/PumaRhino/RhinoPRT.h
@@ -47,6 +47,7 @@ public:
 	bool IsPRTInitialized();
 
 	void SetRPKPath(const std::wstring& rpk_path); // might throw!
+	const std::wstring GetRPKPath() const; 
 
 	int GetRuleAttributeCount();
 	const RuleAttributes& GetRuleAttributes() const;


### PR DESCRIPTION
JIRA: https://zrh-web.esri.com/jira/browse/CE-9378

This issue is caused by a discrepancy between the `PRT` state and the Puma component requesting rule attributes. Since we only have one `PRT` instance, but multiple Puma components, we need to make sure to synchronize the `PRT` state with the Puma component being used.

**Implementation**

I added a `RefreshRpk` function being called each time an attribute is extracted. This function compares the `RPK` being currently setup in the `PRT` state with the one of the Puma component. If they are not the same, `ExpireSolution` is called so that the current component solves itself, resetting the `PRT` state and re-computing the attribute default values. This makes sure `PRT` is in a correct state when extracting parameters.