### PR TITLE
Lor11212/stateless prt wrapper

### DIFF
--- a/PumaGrasshopper/AttributeParameter.cs
+++ b/PumaGrasshopper/AttributeParameter.cs
@@ -93,13 +93,6 @@ namespace PumaGrasshopper.AttributeParameter
             return base.Read(reader);
         }
 
-        protected void RefreshRpk()
-        {
-            var pumaAttributes = (GH_ComponentAttributes)Attributes.GetTopLevel;
-            ComponentPuma puma = (ComponentPuma)pumaAttributes.Owner;
-            puma.RefreshRpk();
-        }
-
         protected void DisplayExtractedParam(IGH_Param param)
         {
             param.CreateAttributes();
@@ -147,10 +140,9 @@ namespace PumaGrasshopper.AttributeParameter
         {
             if (PersistentDataCount > 0) return PersistentData;
 
-            RefreshRpk();
-
             if (mExpectsArray)
             {
+                //TODO refactor -> get value from local attribute list
                 List<List<bool>> defaultValues = PRTWrapper.GetDefaultValuesBooleanArray(Name);
                 if (defaultValues != null)
                 {
@@ -216,10 +208,9 @@ namespace PumaGrasshopper.AttributeParameter
         {
             if (PersistentDataCount > 0) return PersistentData;
 
-            RefreshRpk();
-
             if (mExpectsArray)
             {
+                //TODO refactor -> get value from local attribute list
                 List<List<double>> defaultValues = PRTWrapper.GetDefaultValuesNumberArray(Name);
                 if (defaultValues != null)
                 {
@@ -228,6 +219,7 @@ namespace PumaGrasshopper.AttributeParameter
             }
             else
             {
+                //TODO refactor -> get value from local attribute list
                 List<double> defaultValues = PRTWrapper.GetDefaultValuesNumber(Name);
                 if(defaultValues != null)
                 {
@@ -293,10 +285,9 @@ namespace PumaGrasshopper.AttributeParameter
         {
             if (PersistentDataCount > 0) return PersistentData;
 
-            RefreshRpk();
-
             if (mExpectsArray)
             {
+                //TODO refactor -> get value from local attribute list
                 List<List<string>> defaultValues = PRTWrapper.GetDefaultValuesTextArray(Name);
                 if (defaultValues != null)
                 {
@@ -305,6 +296,7 @@ namespace PumaGrasshopper.AttributeParameter
             }
             else
             {
+                //TODO refactor -> get value from local attribute list
                 List<string> defaultValues = PRTWrapper.GetDefaultValuesText(Name);
                 if (defaultValues != null)
                 {
@@ -379,8 +371,7 @@ namespace PumaGrasshopper.AttributeParameter
         {
             if (PersistentDataCount > 0) return PersistentData;
 
-            RefreshRpk();
-
+            //TODO refactor -> get value from local attribute list
             List<string> defaultValues = PRTWrapper.GetDefaultValuesText(Name);
             if (defaultValues != null)
             {

--- a/PumaGrasshopper/AttributesValuesMap.cs
+++ b/PumaGrasshopper/AttributesValuesMap.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace PumaGrasshopper
 {
-    public class DefaultValuesMap
+    public class AttributesValuesMap
     {
         private Dictionary<string, bool> mDefaultBooleans;
         private Dictionary<string, string> mDefaultStrings;
@@ -17,7 +17,7 @@ namespace PumaGrasshopper
         private Dictionary<string, string[]> mDefaultStringArrays;
         private Dictionary<string, double[]> mDefaultDoubleArrays;
 
-        public DefaultValuesMap(string[] boolKeys, bool[] boolValues, string[] stringKeys, string[] stringValues,
+        public AttributesValuesMap(string[] boolKeys, bool[] boolValues, string[] stringKeys, string[] stringValues,
                                 string[] doubleKeys, double[] doubleValues, string[] boolArrayKeys, string[] boolArrayValues,
                                 string[] stringArrayKeys, string[] stringArrayValues, string[] doubleArrayKeys, string[] doubleArrayValues)
         {
@@ -89,7 +89,7 @@ namespace PumaGrasshopper
             return mDefaultDoubleArrays.TryGetValue(key, out values);
         }
 
-        public static DefaultValuesMap[] FromInteropWrappers(int shapeCount, ref InteropWrapperBoolean boolWrapper,
+        public static AttributesValuesMap[] FromInteropWrappers(int shapeCount, ref InteropWrapperBoolean boolWrapper,
                                                            ref InteropWrapperString stringWrapper,
                                                            ref InteropWrapperDouble doubleWrapper,
                                                            ref InteropWrapperString boolArrayWrapper,
@@ -115,7 +115,7 @@ namespace PumaGrasshopper
             string[] doubleArrayKeys = doubleArrayWrapper.KeysToArray();
             string[] doubleArrayValues = doubleArrayWrapper.ValuesToArray();
 
-            DefaultValuesMap[] defaultValues = new DefaultValuesMap[shapeCount];
+            AttributesValuesMap[] defaultValues = new AttributesValuesMap[shapeCount];
             for (int i = 0; i < shapeCount; ++i)
             {
                 int boolStart = boolStarts[i];
@@ -131,7 +131,7 @@ namespace PumaGrasshopper
                 int stringArrayCount = GetIntervalCount(i, shapeCount, stringArrayStarts, stringArrayKeys.Length);
                 int doubleArrayCount = GetIntervalCount(i, shapeCount, doubleArrayStarts, doubleArrayKeys.Length);
 
-                defaultValues[i] = new DefaultValuesMap(boolKeys.Skip(boolStart).Take(boolCount).ToArray(),
+                defaultValues[i] = new AttributesValuesMap(boolKeys.Skip(boolStart).Take(boolCount).ToArray(),
                     boolValues.Skip(boolStart).Take(boolCount).ToArray(),
                     stringKeys.Skip(stringStart).Take(stringCount).ToArray(), 
                     stringValues.Skip(stringStart).Take(stringCount).ToArray(),
@@ -152,7 +152,7 @@ namespace PumaGrasshopper
             return (currentIndex < shapeCount - 1 ? starts[currentIndex + 1] : itemCount) - starts[currentIndex];
         }
 
-        public static GH_Structure<GH_Boolean> GetDefaultBooleans(string key, DefaultValuesMap[] defaultValues, bool isArray)
+        public static GH_Structure<GH_Boolean> GetDefaultBooleans(string key, AttributesValuesMap[] defaultValues, bool isArray)
         {
             if (isArray)
             {
@@ -177,7 +177,7 @@ namespace PumaGrasshopper
             }
         }
 
-        public static GH_Structure<GH_String> GetDefaultStrings(string key, DefaultValuesMap[] defaultValues, bool isArray)
+        public static GH_Structure<GH_String> GetDefaultStrings(string key, AttributesValuesMap[] defaultValues, bool isArray)
         {
             if (isArray)
             {
@@ -202,7 +202,7 @@ namespace PumaGrasshopper
             }
         }
 
-        public static GH_Structure<GH_Number> GetDefaultDoubles(string key, DefaultValuesMap[] defaultValues, bool isArray)
+        public static GH_Structure<GH_Number> GetDefaultDoubles(string key, AttributesValuesMap[] defaultValues, bool isArray)
         {
             if (isArray)
             {
@@ -229,7 +229,7 @@ namespace PumaGrasshopper
             }
         }
 
-        public static GH_Structure<GH_Colour> GetDefaultColors(string key, DefaultValuesMap[] defaultValues)
+        public static GH_Structure<GH_Colour> GetDefaultColors(string key, AttributesValuesMap[] defaultValues)
         {
             List<string> values = new List<string>(defaultValues.Length);
             for (int i = 0; i < defaultValues.Length; ++i)

--- a/PumaGrasshopper/ComponentPuma.cs
+++ b/PumaGrasshopper/ComponentPuma.cs
@@ -126,6 +126,8 @@ namespace PumaGrasshopper
         /// Stores the optional input parameters
         RuleAttribute[] mRuleAttributes;
 
+        DefaultValuesMap[] mDefaultValues;
+
         bool mDoGenerateMaterials;
 
         public class RulePackage
@@ -215,6 +217,7 @@ namespace PumaGrasshopper
             {
                 mCurrentRpk = rpk;
                 mRuleAttributes = PRTWrapper.GetRuleAttributes(rpk.path);
+                mDefaultValues = PRTWrapper.GetDefaultValues(rpk.path, inputMeshes);
             }
 
             RuleAttributesMap MM = FillAttributesFromNode(DA, inputMeshes.Count);
@@ -585,7 +588,7 @@ namespace PumaGrasshopper
                 if (form.SelectedIndex >= 0 && form.SelectedIndex < mRuleAttributes.Length)
                 {
                     var attr = eligibleAttributes[form.SelectedIndex];
-                    return attr.CreateInputParameter();
+                    return attr.CreateInputParameter(mDefaultValues);
                 }
             }
 

--- a/PumaGrasshopper/ComponentPuma.cs
+++ b/PumaGrasshopper/ComponentPuma.cs
@@ -285,7 +285,7 @@ namespace PumaGrasshopper
 
             for(int shapeId = 0; shapeId < shapeCount; ++shapeId)
             {
-                MM.StartShape();
+                MM.StartNewSection();
 
                 for (int idx = (int)InputParams.SEEDS; idx < Params.Input.Count; ++idx)
                 {

--- a/PumaGrasshopper/ComponentPuma.cs
+++ b/PumaGrasshopper/ComponentPuma.cs
@@ -121,6 +121,8 @@ namespace PumaGrasshopper
             new ParameterDescriptor{ type = ParamType.GENERIC, name = CGA_ERROR_OUTPUT_NAME, nickName = CGA_ERROR_OUTPUT_NICK_NAME, desc = CGA_ERROR_OUTPUT_DESC },
         };
 
+        RulePackage mCurrentRpk;
+
         /// Stores the optional input parameters
         RuleAttribute[] mRuleAttributes;
 
@@ -156,6 +158,8 @@ namespace PumaGrasshopper
             mRuleAttributes = new RuleAttribute[0];
 
             mDoGenerateMaterials = true;
+
+            mCurrentRpk = null;
         }
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
@@ -207,7 +211,11 @@ namespace PumaGrasshopper
             if (inputMeshes == null || inputMeshes.Count == 0)
                 return;
 
-            // TODO: Add default value evaluation
+            if(mCurrentRpk == null || !mCurrentRpk.IsSame(rpk))
+            {
+                mCurrentRpk = rpk;
+                mRuleAttributes = PRTWrapper.GetRuleAttributes(rpk.path);
+            }
 
             RuleAttributesMap MM = FillAttributesFromNode(DA, inputMeshes.Count);
 

--- a/PumaGrasshopper/ComponentPuma.cs
+++ b/PumaGrasshopper/ComponentPuma.cs
@@ -222,7 +222,7 @@ namespace PumaGrasshopper
 
             RuleAttributesMap MM = FillAttributesFromNode(DA, inputMeshes.Count);
 
-            var generatedMeshes = PRTWrapper.GenerateMesh(rpk.path, ref MM, inputMeshes);
+            var generatedMeshes = PRTWrapper.Generate(rpk.path, ref MM, inputMeshes);
             OutputGeometry(DA, generatedMeshes.meshes);
             OutputMaterials(DA, generatedMeshes.materials);
             OutputReports(DA, generatedMeshes.reports);

--- a/PumaGrasshopper/ComponentPuma.cs
+++ b/PumaGrasshopper/ComponentPuma.cs
@@ -126,7 +126,7 @@ namespace PumaGrasshopper
         /// Stores the optional input parameters
         RuleAttribute[] mRuleAttributes;
 
-        DefaultValuesMap[] mDefaultValues;
+        AttributesValuesMap[] mDefaultValues;
 
         bool mDoGenerateMaterials;
 

--- a/PumaGrasshopper/DefaultValuesMap.cs
+++ b/PumaGrasshopper/DefaultValuesMap.cs
@@ -1,0 +1,244 @@
+﻿using Grasshopper.Kernel.Data;
+using Grasshopper.Kernel.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PumaGrasshopper
+{
+    public class DefaultValuesMap
+    {
+        private Dictionary<string, bool> mDefaultBooleans;
+        private Dictionary<string, string> mDefaultStrings;
+        private Dictionary<string, double> mDefaultDoubles;
+        private Dictionary<string, bool[]> mDefaultBoolArrays;
+        private Dictionary<string, string[]> mDefaultStringArrays;
+        private Dictionary<string, double[]> mDefaultDoubleArrays;
+
+        public DefaultValuesMap(string[] boolKeys, bool[] boolValues, string[] stringKeys, string[] stringValues,
+                                string[] doubleKeys, double[] doubleValues, string[] boolArrayKeys, string[] boolArrayValues,
+                                string[] stringArrayKeys, string[] stringArrayValues, string[] doubleArrayKeys, string[] doubleArrayValues)
+        {
+            mDefaultBooleans = new Dictionary<string, bool>();
+            mDefaultStrings = new Dictionary<string, string>();
+            mDefaultDoubles = new Dictionary<string, double>();
+            mDefaultBoolArrays = new Dictionary<string, bool[]>();
+            mDefaultStringArrays = new Dictionary<string, string[]>();
+            mDefaultDoubleArrays = new Dictionary<string, double[]>();
+
+            for(int i = 0; i < boolKeys.Length; ++i)
+            {
+                mDefaultBooleans.Add(boolKeys[i], boolValues[i]);
+            }
+
+            for(int i = 0; i < stringKeys.Length; ++i)
+            {
+                mDefaultStrings.Add(stringKeys[i], stringValues[i]);
+            }
+
+            for(int i = 0; i < doubleKeys.Length; ++i)
+            {
+                mDefaultDoubles.Add(doubleKeys[i], doubleValues[i]);
+            }
+
+            for(int i = 0; i < boolArrayKeys.Length; ++i)
+            {
+                mDefaultBoolArrays.Add(boolArrayKeys[i], Utils.BoolFromCeArray(boolArrayValues[i]));
+            }
+
+            for(int i = 0; i < stringArrayKeys.Length; ++i)
+            {
+                mDefaultStringArrays.Add(stringArrayKeys[i], Utils.StringFromCeArray(stringArrayValues[i]));
+            }
+
+            for(int i = 0; i < doubleArrayKeys.Length; ++i)
+            {
+                mDefaultDoubleArrays.Add(doubleArrayKeys[i], Utils.DoubleFromCeArray(doubleArrayValues[i]));
+            }
+        }
+
+        public bool GetBool(string key, out bool value)
+        {
+            return mDefaultBooleans.TryGetValue(key, out value);
+        }
+
+        public bool GetString(string key, out string value)
+        {
+            return mDefaultStrings.TryGetValue(key, out value);
+        }
+
+        public bool GetDouble(string key, out double value)
+        {
+            return mDefaultDoubles.TryGetValue(key, out value);
+        }
+
+        public bool GetBoolArray(string key, out bool[] values)
+        {
+            return mDefaultBoolArrays.TryGetValue(key, out values);
+        }
+
+        public bool GetStringArray(string key, out string[] values)
+        {
+            return mDefaultStringArrays.TryGetValue(key, out values);
+        }
+
+        public bool GetDoubleArray(string key, out double[] values)
+        {
+            return mDefaultDoubleArrays.TryGetValue(key, out values);
+        }
+
+        public static DefaultValuesMap[] FromInteropWrappers(int shapeCount, ref InteropWrapperBoolean boolWrapper,
+                                                           ref InteropWrapperString stringWrapper,
+                                                           ref InteropWrapperDouble doubleWrapper,
+                                                           ref InteropWrapperString boolArrayWrapper,
+                                                           ref InteropWrapperString stringArrayWrapper,
+                                                           ref InteropWrapperString doubleArrayWrapper)
+        {
+            int[] boolStarts = boolWrapper.StartsToArray();
+            string[] boolKeys = boolWrapper.KeysToArray();
+            bool[] boolValues = boolWrapper.ValuesToArray();
+            int[] stringStarts = stringWrapper.StartsToArray();
+            string[] stringKeys = stringWrapper.KeysToArray();
+            string[] stringValues = stringWrapper.ValuesToArray();
+            int[] doubleStarts = doubleWrapper.StartsToArray();
+            string[] doubleKeys = doubleWrapper.KeysToArray();
+            double[] doubleValues = doubleWrapper.ValuesToArray();
+            int[] boolArrayStarts = boolArrayWrapper.StartsToArray();
+            string[] boolArrayKeys = boolArrayWrapper.KeysToArray();
+            string[] boolArrayValues = boolArrayWrapper.ValuesToArray();
+            int[] stringArrayStarts = stringArrayWrapper.StartsToArray();
+            string[] stringArrayKeys = stringArrayWrapper.KeysToArray();
+            string[] stringArrayValues = stringArrayWrapper.ValuesToArray();
+            int[] doubleArrayStarts = doubleArrayWrapper.StartsToArray();
+            string[] doubleArrayKeys = doubleArrayWrapper.KeysToArray();
+            string[] doubleArrayValues = doubleArrayWrapper.ValuesToArray();
+
+            DefaultValuesMap[] defaultValues = new DefaultValuesMap[shapeCount];
+            for (int i = 0; i < shapeCount; ++i)
+            {
+                int boolStart = boolStarts[i];
+                int stringStart = stringStarts[i];
+                int doubleStart = doubleStarts[i];
+                int boolArrayStart = boolArrayStarts[i];
+                int stringArrayStart = stringArrayStarts[i];
+                int doubleArrayStart = doubleArrayStarts[i];
+                int boolCount = GetIntervalCount(i, shapeCount, boolStarts, boolKeys.Length);
+                int stringCount = GetIntervalCount(i, shapeCount, stringStarts, stringKeys.Length);
+                int doubleCount = GetIntervalCount(i, shapeCount, doubleStarts, doubleKeys.Length);
+                int boolArrayCount = GetIntervalCount(i, shapeCount, boolArrayStarts, boolArrayKeys.Length);
+                int stringArrayCount = GetIntervalCount(i, shapeCount, stringArrayStarts, stringArrayKeys.Length);
+                int doubleArrayCount = GetIntervalCount(i, shapeCount, doubleArrayStarts, doubleArrayKeys.Length);
+
+                defaultValues[i] = new DefaultValuesMap(boolKeys.Skip(boolStart).Take(boolCount).ToArray(),
+                    boolValues.Skip(boolStart).Take(boolCount).ToArray(),
+                    stringKeys.Skip(stringStart).Take(stringCount).ToArray(), 
+                    stringValues.Skip(stringStart).Take(stringCount).ToArray(),
+                    doubleKeys.Skip(doubleStart).Take(doubleCount).ToArray(),
+                    doubleValues.Skip(doubleStart).Take(doubleCount).ToArray(),
+                    boolArrayKeys.Skip(boolArrayStart).Take(boolArrayCount).ToArray(),
+                    boolArrayValues.Skip(boolArrayStart).Take(boolArrayCount).ToArray(),
+                    stringArrayKeys.Skip(stringArrayStart).Take(stringArrayCount).ToArray(),
+                    stringArrayValues.Skip(stringArrayStart).Take(stringArrayCount).ToArray(),
+                    doubleArrayKeys.Skip(doubleArrayStart).Take(doubleArrayCount).ToArray(),
+                    doubleArrayValues.Skip(doubleArrayStart).Take(doubleArrayCount).ToArray());
+            }
+            return defaultValues;
+        }
+
+        public static int GetIntervalCount(int currentIndex, int shapeCount,  int[] starts, int itemCount)
+        {
+            return (currentIndex < shapeCount - 1 ? starts[currentIndex + 1] : itemCount) - starts[currentIndex];
+        }
+
+        public static GH_Structure<GH_Boolean> GetDefaultBooleans(string key, DefaultValuesMap[] defaultValues, bool isArray)
+        {
+            if (isArray)
+            {
+                List<List<bool>> values = new List<List<bool>>(defaultValues.Length);
+                for(int i = 0; i < defaultValues.Length; ++i)
+                {
+                    if (defaultValues[i].GetBoolArray(key, out bool[] value)) values.Add(value.ToList());
+                    else values.Add(new List<bool>());
+                }
+                return Utils.FromListToTree(values);
+            }
+            else
+            {
+                List<bool> values = new List<bool>(defaultValues.Length);
+                for (int i = 0; i < defaultValues.Length; ++i)
+                {
+                    if (defaultValues[i].GetBool(key, out bool value)) values.Add(value);
+                    else values.Add(false);
+                }
+                
+                 return Utils.FromListToTree(values);
+            }
+        }
+
+        public static GH_Structure<GH_String> GetDefaultStrings(string key, DefaultValuesMap[] defaultValues, bool isArray)
+        {
+            if (isArray)
+            {
+                List<List<string>> values = new List<List<string>>(defaultValues.Length);
+                for (int i = 0; i < defaultValues.Length; ++i)
+                {
+                    if (defaultValues[i].GetStringArray(key, out string[] value)) values.Add(value.ToList());
+                    else values.Add(new List<string>());
+                }
+                return Utils.FromListToTree(values);
+            }
+            else
+            {
+                List<string> values = new List<string>(defaultValues.Length);
+                for (int i = 0; i < defaultValues.Length; ++i)
+                {
+                    if (defaultValues[i].GetString(key, out string value)) values.Add(value);
+                    else values.Add("");
+                }
+
+                return Utils.FromListToTree(values);
+            }
+        }
+
+        public static GH_Structure<GH_Number> GetDefaultDoubles(string key, DefaultValuesMap[] defaultValues, bool isArray)
+        {
+            if (isArray)
+            {
+                List<List<double>> values = new List<List<double>>(defaultValues.Length);
+
+                for (int i = 0; i < defaultValues.Length; ++i)
+                {
+                    if (defaultValues[i].GetDoubleArray(key, out double[] value)) values.Add(value.ToList());
+                    else values.Add(new List<double>());
+                }
+                return Utils.FromListToTree(values);
+            }
+            else
+            {
+                List<double> values = new List<double>(defaultValues.Length);
+
+                for (int i = 0; i < defaultValues.Length; ++i)
+                {
+                    if (defaultValues[i].GetDouble(key, out double value)) values.Add(value);
+                    else values.Add(Double.NaN);
+                }
+
+                return Utils.FromListToTree(values);
+            }
+        }
+
+        public static GH_Structure<GH_Colour> GetDefaultColors(string key, DefaultValuesMap[] defaultValues)
+        {
+            List<string> values = new List<string>(defaultValues.Length);
+            for (int i = 0; i < defaultValues.Length; ++i)
+            {
+                if (defaultValues[i].GetString(key, out string value)) values.Add(value);
+                else values.Add("");
+            }
+
+            return Utils.HexListToColorTree(values);
+        }
+    }
+}

--- a/PumaGrasshopper/InteropWrapper.cs
+++ b/PumaGrasshopper/InteropWrapper.cs
@@ -5,11 +5,17 @@ using System.Linq;
 
 namespace PumaGrasshopper
 {
-    class AttributeInterop
+    public class AttributeInterop
     {
         public int Count;
         protected SimpleArrayInt Starts;
         protected ClassArrayString Keys;
+
+        public AttributeInterop()
+        {
+            Starts = new SimpleArrayInt();
+            Count = 0;
+        }
 
         public AttributeInterop(int[] starts, int count)
         {
@@ -25,11 +31,23 @@ namespace PumaGrasshopper
 
         public IntPtr StartsPtr() => Starts.ConstPointer();
         public IntPtr KeysPtr() => Keys.ConstPointer();
+
+        public IntPtr StartsNonConstPtr() => Starts.NonConstPointer();
+        public IntPtr KeysNonConstPtr() => Keys.NonConstPointer();
+
+        public int[] StartsToArray() => Starts.ToArray();
+        public string[] KeysToArray() => Keys.ToArray();
     }
 
-    class InteropWrapperString : AttributeInterop
+    public class InteropWrapperString : AttributeInterop
     {
         private ClassArrayString Values;
+
+        public InteropWrapperString(): base()
+        {
+            Keys = new ClassArrayString();
+            Values = new ClassArrayString();
+        }
 
         public InteropWrapperString(int[] starts, ref List<string> keys, ref List<string> values) : base(starts, keys.Count)
         {
@@ -51,11 +69,20 @@ namespace PumaGrasshopper
         }
 
         public IntPtr ValuesPtr() => Values.ConstPointer();
+        public IntPtr ValuesNonConstPtr() => Values.NonConstPointer();
+
+        public string[] ValuesToArray() => Values.ToArray();
     }
 
-    class InteropWrapperDouble: AttributeInterop
+    public class InteropWrapperDouble: AttributeInterop
     {
         private SimpleArrayDouble Values;
+
+        public InteropWrapperDouble(): base()
+        {
+            Keys = new ClassArrayString();
+            Values = new SimpleArrayDouble();
+        }
 
         public InteropWrapperDouble(int[] starts, ref List<string> keys, ref List<double> values): base(starts, keys.Count)
         {
@@ -75,11 +102,20 @@ namespace PumaGrasshopper
         }
 
         public IntPtr ValuesPtr() => Values.ConstPointer();
+        public IntPtr ValuesNonConstPtr() => Values.NonConstPointer();
+
+        public double[] ValuesToArray() => Values.ToArray();
     }
 
-    class InteropWrapperBoolean: AttributeInterop
+    public class InteropWrapperBoolean: AttributeInterop
     {
         private SimpleArrayInt Values;
+
+        public InteropWrapperBoolean(): base()
+        {
+            Keys = new ClassArrayString();
+            Values = new SimpleArrayInt();
+        }
 
         public InteropWrapperBoolean(int[] starts, ref List<string> keys, ref List<bool> values): base(starts, keys.Count)
         {
@@ -99,5 +135,8 @@ namespace PumaGrasshopper
         }
 
         public IntPtr ValuesPtr() => Values.ConstPointer();
+        public IntPtr ValuesNonConstPtr() => Values.NonConstPointer();
+
+        public bool[] ValuesToArray() => Array.ConvertAll(Values.ToArray(), value => Convert.ToBoolean(value));
     }
 }

--- a/PumaGrasshopper/InteropWrapper.cs
+++ b/PumaGrasshopper/InteropWrapper.cs
@@ -31,15 +31,16 @@ namespace PumaGrasshopper
     {
         private ClassArrayString Values;
 
-        public InteropWrapperString(int[] starts, Dictionary<string, string> attributes) : base(starts, attributes.Count)
+        public InteropWrapperString(int[] starts, ref List<string> keys, ref List<string> values) : base(starts, keys.Count)
         {
             Keys = new ClassArrayString();
             Values = new ClassArrayString();
 
-            foreach (var attribute in attributes)
+            
+            for (int i = 0; i < keys.Count; ++i)
             {
-                Keys.Add(attribute.Key);
-                Values.Add(attribute.Value);
+                Keys.Add(keys[i]);
+                Values.Add(values[i]);
             }
         }
 
@@ -56,16 +57,17 @@ namespace PumaGrasshopper
     {
         private SimpleArrayDouble Values;
 
-        public InteropWrapperDouble(int[] starts, Dictionary<string, double> attributes): base(starts, attributes.Count)
+        public InteropWrapperDouble(int[] starts, ref List<string> keys, ref List<double> values): base(starts, keys.Count)
         {
             Keys = new ClassArrayString();
-            Values = new SimpleArrayDouble(attributes.Values);
+            Values = new SimpleArrayDouble(values);
 
-            foreach(var key in attributes.Keys)
+            foreach(var key in keys)
             {
                 Keys.Add(key);
             }
         }
+
         public new void Dispose()
         {
             base.Dispose();
@@ -79,14 +81,14 @@ namespace PumaGrasshopper
     {
         private SimpleArrayInt Values;
 
-        public InteropWrapperBoolean(int[] starts, Dictionary<string, bool> attributes): base(starts, attributes.Count)
+        public InteropWrapperBoolean(int[] starts, ref List<string> keys, ref List<bool> values): base(starts, keys.Count)
         {
             Keys = new ClassArrayString();
-            Values = new SimpleArrayInt(Array.ConvertAll<bool, int>(attributes.Values.ToArray(), x => Convert.ToInt32(x)));
+            Values = new SimpleArrayInt(Array.ConvertAll<bool, int>(values.ToArray(), x => Convert.ToInt32(x)));
 
-            foreach (var attribute in attributes)
+            foreach (var key in keys)
             {
-                Keys.Add(attribute.Key);
+                Keys.Add(key);
             }
         }
 

--- a/PumaGrasshopper/InteropWrapper.cs
+++ b/PumaGrasshopper/InteropWrapper.cs
@@ -1,0 +1,101 @@
+﻿using Rhino.Runtime.InteropWrappers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PumaGrasshopper
+{
+    class AttributeInterop
+    {
+        public int Count;
+        protected SimpleArrayInt Starts;
+        protected ClassArrayString Keys;
+
+        public AttributeInterop(int[] starts, int count)
+        {
+            Starts = new SimpleArrayInt(starts);
+            Count = count;
+        }
+
+        public void Dispose()
+        {
+            Starts.Dispose();
+            Keys.Dispose();
+        }
+
+        public IntPtr StartsPtr() => Starts.ConstPointer();
+        public IntPtr KeysPtr() => Keys.ConstPointer();
+    }
+
+    class InteropWrapperString : AttributeInterop
+    {
+        private ClassArrayString Values;
+
+        public InteropWrapperString(int[] starts, Dictionary<string, string> attributes) : base(starts, attributes.Count)
+        {
+            Keys = new ClassArrayString();
+            Values = new ClassArrayString();
+
+            foreach (var attribute in attributes)
+            {
+                Keys.Add(attribute.Key);
+                Values.Add(attribute.Value);
+            }
+        }
+
+        public new void Dispose()
+        {
+            base.Dispose();
+            Values.Dispose();
+        }
+
+        public IntPtr ValuesPtr() => Values.ConstPointer();
+    }
+
+    class InteropWrapperDouble: AttributeInterop
+    {
+        private SimpleArrayDouble Values;
+
+        public InteropWrapperDouble(int[] starts, Dictionary<string, double> attributes): base(starts, attributes.Count)
+        {
+            Keys = new ClassArrayString();
+            Values = new SimpleArrayDouble(attributes.Values);
+
+            foreach(var key in attributes.Keys)
+            {
+                Keys.Add(key);
+            }
+        }
+        public new void Dispose()
+        {
+            base.Dispose();
+            Values.Dispose();
+        }
+
+        public IntPtr ValuesPtr() => Values.ConstPointer();
+    }
+
+    class InteropWrapperBoolean: AttributeInterop
+    {
+        private SimpleArrayInt Values;
+
+        public InteropWrapperBoolean(int[] starts, Dictionary<string, bool> attributes): base(starts, attributes.Count)
+        {
+            Keys = new ClassArrayString();
+            Values = new SimpleArrayInt(Array.ConvertAll<bool, int>(attributes.Values.ToArray(), x => Convert.ToInt32(x)));
+
+            foreach (var attribute in attributes)
+            {
+                Keys.Add(attribute.Key);
+            }
+        }
+
+        public new void Dispose()
+        {
+            base.Dispose();
+            Values.Dispose();
+        }
+
+        public IntPtr ValuesPtr() => Values.ConstPointer();
+    }
+}

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -78,6 +78,16 @@ namespace PumaGrasshopper
         public static extern int GetRuleAttributes(string rpk_path, [Out] IntPtr pAttributesBuffer, [Out] IntPtr pAttributesTypes, [Out] IntPtr pBaseAnnotations, [Out] IntPtr pDoubleAnnotations, [Out] IntPtr pStringAnnotations);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
+        public static extern bool GetDefaultAttributes(
+            string rpk_path, [In] IntPtr pMeshes, 
+            [Out] IntPtr pBoolStarts, [Out] IntPtr pBoolKeys, [Out] IntPtr pBoolVals, 
+            [Out] IntPtr pDoubleStarts, [Out] IntPtr pDoubleKeys, [Out] IntPtr pDoubleVals, 
+            [Out] IntPtr pStringStarts, [Out] IntPtr pStringKeys, [Out] IntPtr pStringVals,
+            [Out] IntPtr pBoolArrayStarts, [Out] IntPtr pBoolArrayKeys, [Out] IntPtr pBoolArrayVals,
+            [Out] IntPtr pDoubleArrayStarts, [Out] IntPtr pDoubleArrayKeys, [Out] IntPtr pDoubleArrayVals,
+            [Out] IntPtr pStringArrayStarts, [Out] IntPtr pStringArrayKeys, [Out] IntPtr pStringArrayVals);
+
+        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern void GetCGAPrintOutput(int initialShapeIndex, [In, Out] IntPtr pPrintOutput);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
@@ -357,6 +367,58 @@ namespace PumaGrasshopper
             }
 
             return generationResult;
+        }
+
+        public static DefaultValuesMap[] GetDefaultValues(string rulePkg, List<Mesh> initialMeshes)
+        {
+            SimpleArrayMeshPointer initialMeshesArray = new SimpleArrayMeshPointer();
+            foreach (var mesh in initialMeshes)
+            {
+                initialMeshesArray.Add(mesh, true);
+            }
+
+            var stringWrapper = new InteropWrapperString();
+            var boolWrapper = new InteropWrapperBoolean();
+            var doubleWrapper = new InteropWrapperDouble();
+            var stringArrayWrapper = new InteropWrapperString();
+            var boolArrayWrapper = new InteropWrapperString();
+            var doubleArrayWrapper = new InteropWrapperString();
+
+
+            bool status = GetDefaultAttributes(rulePkg, initialMeshesArray.ConstPointer(), 
+                boolWrapper.StartsNonConstPtr(), boolWrapper.KeysNonConstPtr(), boolWrapper.ValuesNonConstPtr(),
+                doubleWrapper.StartsNonConstPtr(), doubleWrapper.KeysNonConstPtr(), doubleWrapper.ValuesNonConstPtr(),
+                stringWrapper.StartsNonConstPtr(), stringWrapper.KeysNonConstPtr(), stringWrapper.ValuesNonConstPtr(),
+                boolArrayWrapper.StartsNonConstPtr(), boolArrayWrapper.KeysNonConstPtr(), boolArrayWrapper.ValuesNonConstPtr(),
+                doubleArrayWrapper.StartsNonConstPtr(), doubleArrayWrapper.KeysNonConstPtr(), doubleArrayWrapper.ValuesNonConstPtr(),
+                stringArrayWrapper.StartsNonConstPtr(), stringArrayWrapper.KeysNonConstPtr(), stringArrayWrapper.ValuesNonConstPtr());
+
+            if (!status)
+            {
+                stringWrapper.Dispose();
+                boolWrapper.Dispose();
+                doubleWrapper.Dispose();
+                stringArrayWrapper.Dispose();
+                doubleArrayWrapper.Dispose();
+                boolArrayWrapper.Dispose();
+                return null;
+            }
+
+            var defaultValues = DefaultValuesMap.FromInteropWrappers(initialMeshes.Count, ref boolWrapper, ref stringWrapper, ref doubleWrapper, ref boolArrayWrapper, ref stringArrayWrapper, ref doubleArrayWrapper);
+            
+            stringWrapper.Dispose();
+            boolWrapper.Dispose();
+            doubleWrapper.Dispose();
+            stringArrayWrapper.Dispose();
+            doubleArrayWrapper.Dispose();
+            boolArrayWrapper.Dispose();
+
+            return defaultValues;
+        }
+
+
+        public static void DecodeDefaultValues<T>(int[] starts, string[] keys, T[] values) {
+            
         }
 
         public static List<String> GetCGAPrintOutput(int initialShapeIndex)

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -57,7 +57,7 @@ namespace PumaGrasshopper
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ClearInitialShapes();
 
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern int Generate(string rpk_path, [Out] IntPtr errorMsg,
             int shapeCount,
             [In] IntPtr pBoolStarts, int boolCount,
@@ -228,10 +228,11 @@ namespace PumaGrasshopper
                      pReportBoolArray,
                      pReportStringArray);
 
-            initialMeshesArray.Dispose();
+            // initialMeshesArray.Dispose();
             boolWrapper.Dispose();
             doubleWrapper.Dispose();
             stringWrapper.Dispose();
+            initialMeshesArray.Dispose();
 
             var meshCountsArray = meshCounts.ToArray();
             var meshesArray = meshes.ToNonConstArray();
@@ -591,7 +592,7 @@ namespace PumaGrasshopper
         {
             SimpleArrayInt boolArray = new SimpleArrayInt();
             var pBoolArray = boolArray.NonConstPointer();
-            bool hasDefault = GetDefaultValuesBoolean(key, pBoolArray);
+            bool hasDefault = false; //  GetDefaultValuesBoolean(key, pBoolArray);
 
             if (!hasDefault) return null;
 
@@ -605,7 +606,7 @@ namespace PumaGrasshopper
         {
             SimpleArrayDouble doubleArray = new SimpleArrayDouble();
             var pDoubleArray = doubleArray.NonConstPointer();
-            bool hasDefault = GetDefaultValuesNumber(key, pDoubleArray);
+            bool hasDefault = false; //GetDefaultValuesNumber(key, pDoubleArray);
 
             if (!hasDefault) return null;
 
@@ -619,7 +620,7 @@ namespace PumaGrasshopper
         {
             ClassArrayString stringArray = new ClassArrayString();
             var pStringArray = stringArray.NonConstPointer();
-            bool hasDefault = GetDefaultValuesText(key, pStringArray);
+            bool hasDefault = false; // GetDefaultValuesText(key, pStringArray);
 
             if (!hasDefault) return null;
 

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -105,7 +105,7 @@ namespace PumaGrasshopper
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern bool GetDefaultValuesTextArray(string key, [In, Out] IntPtr pTexts, [In, Out] IntPtr pSizes);
 
-        public static GenerationResult GenerateMesh(string rpkPath,
+        public static GenerationResult Generate(string rpkPath,
             ref RuleAttributesMap MM,
             List<Mesh> initialMeshes)
         {

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -369,7 +369,7 @@ namespace PumaGrasshopper
             return generationResult;
         }
 
-        public static DefaultValuesMap[] GetDefaultValues(string rulePkg, List<Mesh> initialMeshes)
+        public static AttributesValuesMap[] GetDefaultValues(string rulePkg, List<Mesh> initialMeshes)
         {
             SimpleArrayMeshPointer initialMeshesArray = new SimpleArrayMeshPointer();
             foreach (var mesh in initialMeshes)
@@ -404,7 +404,7 @@ namespace PumaGrasshopper
                 return null;
             }
 
-            var defaultValues = DefaultValuesMap.FromInteropWrappers(initialMeshes.Count, ref boolWrapper, ref stringWrapper, ref doubleWrapper, ref boolArrayWrapper, ref stringArrayWrapper, ref doubleArrayWrapper);
+            var defaultValues = AttributesValuesMap.FromInteropWrappers(initialMeshes.Count, ref boolWrapper, ref stringWrapper, ref doubleWrapper, ref boolArrayWrapper, ref stringArrayWrapper, ref doubleArrayWrapper);
             
             stringWrapper.Dispose();
             boolWrapper.Dispose();

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -36,13 +36,13 @@ namespace PumaGrasshopper
     /// <summary>
     /// Encapsulate PumaRhino library.
     /// </summary>
-    class PRTWrapper
+    public static class PRTWrapper
     {
         public static String INIT_SHAPE_IDX_KEY = "InitShapeIdx";
         private const String PUMA_RHINO_LIBRARY = "PumaRhino.rhp";
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
-        public static extern void GetProductVersion([In, Out]IntPtr version_Str);
+        public static extern void GetProductVersion([In, Out] IntPtr version_Str);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern bool InitializeRhinoPRT();
@@ -54,16 +54,30 @@ namespace PumaGrasshopper
         public static extern bool GetPackagePath([In, Out] IntPtr pRpk);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
-        public static extern bool AddInitialMesh([In]IntPtr pMesh);
+        public static extern bool AddInitialMesh([In] IntPtr pMesh);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ClearInitialShapes();
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int Generate([In, Out] IntPtr pMeshCounts, [In, Out] IntPtr pMeshArray);
+        public static extern int Generate([In] IntPtr rpk_path, [Out] IntPtr errorMsg,
+            int shapeCount,
+            [In] IntPtr pBoolStarts, int boolCount,
+            [In] IntPtr pBoolKeys, [In] IntPtr pBoolVals,
+            [In] IntPtr pDoubleStarts, int doubleCount,
+            [In] IntPtr pDoubleKeys, [In] IntPtr pDoubleVals,
+            [In] IntPtr pStringStarts, int stringCount,
+            [In] IntPtr pStringKeys, [In] IntPtr pStringVals,
+            [In] IntPtr pBoolArrayStarts, int boolArrayCount,
+            [In] IntPtr pBoolArrayKeys, [In] IntPtr pBoolArrayVals,
+            [In] IntPtr pDoubleArrayStarts, [In] IntPtr doubleArrayCount,
+            [In] IntPtr pDoubleArrayKeys, [In] IntPtr pDoubleArrayVals,
+            [In] IntPtr pStringArrayStarts, [In] IntPtr stringArrayCount,
+            [In] IntPtr pStringArrayKeys, [In] IntPtr pStringArrayVals,
+            [In] IntPtr pInitialMeshes, [Out] IntPtr pMeshCounts, [Out] IntPtr pMeshArray);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
-        public static extern bool GetMeshBundle(int initialShapeIndex, [In, Out]IntPtr pMeshArray);
+        public static extern bool GetMeshBundle(int initialShapeIndex, [In, Out] IntPtr pMeshArray);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern int GetMeshPartCount(int initialShapeIndex);
@@ -72,7 +86,7 @@ namespace PumaGrasshopper
         public static extern int GetRuleAttributesCount();
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern bool GetRuleAttribute(int attrIdx, [In, Out]IntPtr pRule, [In, Out]IntPtr pName, [In, Out]IntPtr pNickname, ref Annotations.AnnotationArgumentType type, [In,Out]IntPtr pGroup);
+        public static extern bool GetRuleAttribute(int attrIdx, [In, Out] IntPtr pRule, [In, Out] IntPtr pName, [In, Out] IntPtr pNickname, ref Annotations.AnnotationArgumentType type, [In, Out] IntPtr pGroup);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern void SetRuleAttributeDouble(int initialShapeIndex, string fullName, double value);
@@ -87,25 +101,25 @@ namespace PumaGrasshopper
         public static extern void SetRuleAttributeString(int initialShapeIndex, string fullName, string value);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern void SetRuleAttributeDoubleArray(int initialShapeIndex, string fullName, [In, Out]IntPtr pValueArray);
+        public static extern void SetRuleAttributeDoubleArray(int initialShapeIndex, string fullName, [In, Out] IntPtr pValueArray);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern void SetRuleAttributeBoolArray(int initialShapeIndex, string fullName, [In, Out]IntPtr pValueArray);
+        public static extern void SetRuleAttributeBoolArray(int initialShapeIndex, string fullName, [In, Out] IntPtr pValueArray);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern void SetRuleAttributeStringArray(int initialShapeIndex, string fullName, [In, Out]IntPtr pValueArray);
+        public static extern void SetRuleAttributeStringArray(int initialShapeIndex, string fullName, [In, Out] IntPtr pValueArray);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void GetAnnotationTypes(int ruleIdx, [In, Out]IntPtr pAnnotTypeArray);
+        public static extern void GetAnnotationTypes(int ruleIdx, [In, Out] IntPtr pAnnotTypeArray);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern bool GetEnumType(int ruleIdx, int enumIdx, ref Annotations.EnumAnnotationType type);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
-        public static extern bool GetAnnotationEnumDouble(int ruleIdx, int enumIdx, [In,Out]IntPtr pArray, ref bool restricted);
+        public static extern bool GetAnnotationEnumDouble(int ruleIdx, int enumIdx, [In, Out] IntPtr pArray, ref bool restricted);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern bool GetAnnotationEnumString(int ruleIdx, int enumIdx, [In,Out]IntPtr pArray, ref bool restricted);
+        public static extern bool GetAnnotationEnumString(int ruleIdx, int enumIdx, [In, Out] IntPtr pArray, ref bool restricted);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern bool GetAnnotationRange(int ruleIdx, int enumIdx, ref double min, ref double max, ref double stepsize, ref bool restricted);
@@ -161,7 +175,7 @@ namespace PumaGrasshopper
             StringWrapper rpk = new StringWrapper();
             var rpkPtr = rpk.NonConstPointer;
             bool success = GetPackagePath(rpkPtr);
-            if(success)
+            if (success)
             {
                 currentRpk = rpk.ToString();
             }
@@ -188,15 +202,62 @@ namespace PumaGrasshopper
             return status;
         }
 
-        public static List<Mesh[]> GenerateMesh()
+        public static List<Mesh[]> GenerateMesh(string rpkPath,
+            int[] stringStarts,
+            int[] doubleStarts,
+            int[] boolStarts,
+            Dictionary<string, bool> boolAttributes, 
+            Dictionary<string, double> doubleAttributes, 
+            Dictionary<string, string> stringAttributes,
+            Dictionary<string, bool[]> boolArrayAttributes,
+            Dictionary<string, double[]> doubleArrayAttributes,
+            Dictionary<string, string[]> stringArrayAttributes,
+            List<Mesh> initialMeshes)
         {
+            SimpleArrayMeshPointer initialMeshesArray = new SimpleArrayMeshPointer();
+            foreach(var mesh in initialMeshes)
+            {
+                initialMeshesArray.Add(mesh, true);
+            }
+            var pMeshesArray = initialMeshesArray.ConstPointer();
+
+
             var meshCounts = new SimpleArrayInt();
             var pMeshCounts = meshCounts.NonConstPointer();
 
             var meshes = new SimpleArrayMeshPointer();
             var pMeshes = meshes.NonConstPointer();
 
-            Generate(pMeshCounts, pMeshes);
+            var stringWrapper = new InteropWrapperString(stringStarts, stringAttributes);
+            var boolWrapper = new InteropWrapperBoolean(boolStarts, boolAttributes);
+            var doubleWrapper = new InteropWrapperDouble(doubleStarts, doubleAttributes);
+
+            StringWrapper errorMsg = new StringWrapper("");
+            IntPtr pErrorMsg = errorMsg.NonConstPointer;
+
+            Generate(rpkPath,
+                     pErrorMsg,
+                     initialMeshes.Count,
+                     boolWrapper.StartsPtr(),
+                     boolWrapper.Count,
+                     boolWrapper.KeysPtr(),
+                     boolWrapper.ValuesPtr(),
+                     doubleWrapper.StartsPtr(),
+                     doubleWrapper.Count,
+                     doubleWrapper.KeysPtr(),
+                     doubleWrapper.ValuesPtr(),
+                     stringWrapper.StartsPtr(),
+                     stringWrapper.Count,
+                     stringWrapper.KeysPtr(),
+                     stringWrapper.ValuesPtr(),
+                     pMeshesArray,
+                     pMeshCounts,
+                     pMeshes);
+
+            initialMeshesArray.Dispose();
+            boolWrapper.Dispose();
+            doubleWrapper.Dispose();
+            stringWrapper.Dispose();
 
             var meshCountsArray = meshCounts.ToArray();
             var meshesArray = meshes.ToNonConstArray();

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -54,9 +54,6 @@ namespace PumaGrasshopper
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern bool InitializeRhinoPRT();
 
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void ClearInitialShapes();
-
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern int Generate(string rpk_path, [Out] IntPtr errorMsg,
             int shapeCount,
@@ -76,12 +73,6 @@ namespace PumaGrasshopper
             [Out] IntPtr pColorsArray, [Out] IntPtr pTexIndices, [Out] IntPtr pTexKeys, [Out] IntPtr pTexPaths,
             [Out] IntPtr pReportCountArray, [Out] IntPtr pReportKeyArray, [Out] IntPtr pReportDoubleArray,
             [Out] IntPtr pReportBoolArray, [Out] IntPtr pReportStringArray);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
-        public static extern bool GetMeshBundle(int initialShapeIndex, [In, Out] IntPtr pMeshArray);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int GetMeshPartCount(int initialShapeIndex);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern int GetRuleAttributesCount();
@@ -105,26 +96,10 @@ namespace PumaGrasshopper
         public static extern bool GetAnnotationRange(int ruleIdx, int enumIdx, ref double min, ref double max, ref double stepsize, ref bool restricted);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern void GetReports(int initialShapeIndex, [In, Out] IntPtr pKeysArray,
-        [In, Out] IntPtr pDoubleReports,
-        [In, Out] IntPtr pBoolReports,
-        [In, Out] IntPtr pStringReports);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern void GetCGAPrintOutput(int initialShapeIndex, [In, Out] IntPtr pPrintOutput);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern void GetCGAErrorOutput(int initialShapeIndex, [In, Out] IntPtr pErrorOutput);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern bool GetMaterial(int initialShapeIndex, int shapeID, ref int pUvSet,
-                                                [In, Out] IntPtr pTexKeys,
-                                                [In, Out] IntPtr pTexPaths,
-                                                [In, Out] IntPtr pDiffuseColor,
-                                                [In, Out] IntPtr pAmbientColor,
-                                                [In, Out] IntPtr pSpecularColor,
-                                                ref double opacity,
-                                                ref double shininess);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern void SetMaterialGenerationOption(bool doGenerate);
@@ -228,11 +203,10 @@ namespace PumaGrasshopper
                      pReportBoolArray,
                      pReportStringArray);
 
-            // initialMeshesArray.Dispose();
+            initialMeshesArray.Dispose();
             boolWrapper.Dispose();
             doubleWrapper.Dispose();
             stringWrapper.Dispose();
-            initialMeshesArray.Dispose();
 
             var meshCountsArray = meshCounts.ToArray();
             var meshesArray = meshes.ToNonConstArray();

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -47,20 +47,11 @@ namespace PumaGrasshopper
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern bool InitializeRhinoPRT();
 
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern void SetPackage(string rpk_path, [In, Out] IntPtr errorMsg);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern bool GetPackagePath([In, Out] IntPtr pRpk);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
-        public static extern bool AddInitialMesh([In] IntPtr pMesh);
-
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern void ClearInitialShapes();
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int Generate([In] IntPtr rpk_path, [Out] IntPtr errorMsg,
+        public static extern int Generate(string rpk_path, [Out] IntPtr errorMsg,
             int shapeCount,
             [In] IntPtr pBoolStarts, int boolCount,
             [In] IntPtr pBoolKeys, [In] IntPtr pBoolVals,
@@ -70,9 +61,9 @@ namespace PumaGrasshopper
             [In] IntPtr pStringKeys, [In] IntPtr pStringVals,
             [In] IntPtr pBoolArrayStarts, int boolArrayCount,
             [In] IntPtr pBoolArrayKeys, [In] IntPtr pBoolArrayVals,
-            [In] IntPtr pDoubleArrayStarts, [In] IntPtr doubleArrayCount,
+            [In] IntPtr pDoubleArrayStarts, int doubleArrayCount,
             [In] IntPtr pDoubleArrayKeys, [In] IntPtr pDoubleArrayVals,
-            [In] IntPtr pStringArrayStarts, [In] IntPtr stringArrayCount,
+            [In] IntPtr pStringArrayStarts, int stringArrayCount,
             [In] IntPtr pStringArrayKeys, [In] IntPtr pStringArrayVals,
             [In] IntPtr pInitialMeshes, [Out] IntPtr pMeshCounts, [Out] IntPtr pMeshArray);
 
@@ -87,27 +78,6 @@ namespace PumaGrasshopper
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern bool GetRuleAttribute(int attrIdx, [In, Out] IntPtr pRule, [In, Out] IntPtr pName, [In, Out] IntPtr pNickname, ref Annotations.AnnotationArgumentType type, [In, Out] IntPtr pGroup);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern void SetRuleAttributeDouble(int initialShapeIndex, string fullName, double value);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern void SetRuleAttributeBoolean(int initialShapeIndex, string fullName, bool value);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern void SetRuleAttributeInteger(int initialShapeIndex, string fullName, int value);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern void SetRuleAttributeString(int initialShapeIndex, string fullName, string value);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern void SetRuleAttributeDoubleArray(int initialShapeIndex, string fullName, [In, Out] IntPtr pValueArray);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern void SetRuleAttributeBoolArray(int initialShapeIndex, string fullName, [In, Out] IntPtr pValueArray);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern void SetRuleAttributeStringArray(int initialShapeIndex, string fullName, [In, Out] IntPtr pValueArray);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern void GetAnnotationTypes(int ruleIdx, [In, Out] IntPtr pAnnotTypeArray);
@@ -150,15 +120,6 @@ namespace PumaGrasshopper
         public static extern void SetMaterialGenerationOption(bool doGenerate);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern bool GetDefaultValuesBoolean(string key, [In, Out] IntPtr pValues);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern bool GetDefaultValuesNumber(string key, [In, Out] IntPtr pValues);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern bool GetDefaultValuesText(string key, [In, Out] IntPtr pTexts);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern bool GetDefaultValuesBooleanArray(string key, [In, Out] IntPtr pValues, [In, Out] IntPtr pSizes);
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
@@ -167,51 +128,8 @@ namespace PumaGrasshopper
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern bool GetDefaultValuesTextArray(string key, [In, Out] IntPtr pTexts, [In, Out] IntPtr pSizes);
 
-
-        public static string GetPackagePath()
-        {
-            string currentRpk = null;
-
-            StringWrapper rpk = new StringWrapper();
-            var rpkPtr = rpk.NonConstPointer;
-            bool success = GetPackagePath(rpkPtr);
-            if (success)
-            {
-                currentRpk = rpk.ToString();
-            }
-            rpk.Dispose();
-
-            return currentRpk;
-        }
-
-        public static bool AddMesh(List<Mesh> meshes)
-        {
-            bool status;
-
-            using (var arr = new SimpleArrayMeshPointer())
-            {
-                foreach (var mesh in meshes)
-                {
-                    arr.Add(mesh, true);
-                }
-
-                var ptr_array = arr.ConstPointer();
-                status = AddInitialMesh(ptr_array);
-            }
-
-            return status;
-        }
-
         public static List<Mesh[]> GenerateMesh(string rpkPath,
-            int[] stringStarts,
-            int[] doubleStarts,
-            int[] boolStarts,
-            Dictionary<string, bool> boolAttributes, 
-            Dictionary<string, double> doubleAttributes, 
-            Dictionary<string, string> stringAttributes,
-            Dictionary<string, bool[]> boolArrayAttributes,
-            Dictionary<string, double[]> doubleArrayAttributes,
-            Dictionary<string, string[]> stringArrayAttributes,
+            ref RuleAttributesMap MM,
             List<Mesh> initialMeshes)
         {
             SimpleArrayMeshPointer initialMeshesArray = new SimpleArrayMeshPointer();
@@ -228,9 +146,12 @@ namespace PumaGrasshopper
             var meshes = new SimpleArrayMeshPointer();
             var pMeshes = meshes.NonConstPointer();
 
-            var stringWrapper = new InteropWrapperString(stringStarts, stringAttributes);
-            var boolWrapper = new InteropWrapperBoolean(boolStarts, boolAttributes);
-            var doubleWrapper = new InteropWrapperDouble(doubleStarts, doubleAttributes);
+            var stringWrapper = new InteropWrapperString(MM.GetStringStarts(), ref MM.stringKeys, ref MM.stringValues);
+            var boolWrapper = new InteropWrapperBoolean(MM.GetBoolStarts(), ref MM.boolKeys, ref MM.boolValues);
+            var doubleWrapper = new InteropWrapperDouble(MM.GetDoubleStarts(), ref MM.doubleKeys, ref MM.doubleValues);
+            var stringArrayWrapper = new InteropWrapperString(MM.GetStringArrayStarts(), ref MM.stringArrayKeys, ref MM.stringArrayValues);
+            var boolArrayWrapper = new InteropWrapperString(MM.GetBoolArrayStarts(), ref MM.boolArrayKeys, ref MM.boolArrayValues);
+            var doubleArrayWrapper = new InteropWrapperString(MM.GetDoubleArrayStarts(), ref MM.doubleArrayKeys, ref MM.doubleArrayValues);
 
             StringWrapper errorMsg = new StringWrapper("");
             IntPtr pErrorMsg = errorMsg.NonConstPointer;
@@ -250,6 +171,18 @@ namespace PumaGrasshopper
                      stringWrapper.Count,
                      stringWrapper.KeysPtr(),
                      stringWrapper.ValuesPtr(),
+                     boolArrayWrapper.StartsPtr(),
+                     boolArrayWrapper.Count,
+                     boolArrayWrapper.KeysPtr(),
+                     boolArrayWrapper.ValuesPtr(),
+                     doubleArrayWrapper.StartsPtr(),
+                     doubleArrayWrapper.Count,
+                     doubleArrayWrapper.KeysPtr(),
+                     doubleArrayWrapper.ValuesPtr(),
+                     stringArrayWrapper.StartsPtr(),
+                     stringArrayWrapper.Count,
+                     stringArrayWrapper.KeysPtr(),
+                     stringArrayWrapper.ValuesPtr(),
                      pMeshesArray,
                      pMeshCounts,
                      pMeshes);
@@ -678,41 +611,6 @@ namespace PumaGrasshopper
                 return new Annotations.Range(min, max, stepsize, restricted);
             }
             return null;
-        }
-
-        public static void SetRuleAttributeDoubleArray(int initialShapeIndex, string fullName, List<double> doubleList)
-        {
-            if (doubleList.Count == 0) return;
-
-            using (SimpleArrayDouble array = new SimpleArrayDouble(doubleList))
-            {
-                var pArray = array.ConstPointer();
-                PRTWrapper.SetRuleAttributeDoubleArray(initialShapeIndex, fullName, pArray);
-            }
-        }
-
-        public static void SetRuleAttributeBoolArray(int initialShapeIndex, string fullName, List<Boolean> boolList)
-        {
-            if (boolList.Count == 0) return;
-
-            using(SimpleArrayInt array = new SimpleArrayInt(Array.ConvertAll<bool, int>(boolList.ToArray(), x => Convert.ToInt32(x))))
-            {
-                var pArray = array.ConstPointer();
-                PRTWrapper.SetRuleAttributeBoolArray(initialShapeIndex, fullName, pArray);
-            }
-        }
-
-        public static void SetRuleAttributeStringArray(int initialShapeIndex, string fullName, List<string> stringList)
-        {
-            if (stringList.Count == 0) return;
-
-            using(ClassArrayString array = new ClassArrayString())
-            {
-                stringList.ForEach(x => array.Add(x));
-
-                var pArray = array.ConstPointer();
-                PRTWrapper.SetRuleAttributeStringArray(initialShapeIndex, fullName, pArray);
-            }
         }
 
         public static List<bool> GetDefaultValuesBoolean(string key)

--- a/PumaGrasshopper/PumaGrasshopper.csproj
+++ b/PumaGrasshopper/PumaGrasshopper.csproj
@@ -29,7 +29,7 @@
     <TargetExt>.gha</TargetExt>
     <OutputPath>..\build\</OutputPath>
     <PlatformTarget>x64</PlatformTarget>
-    <Optimize>false</Optimize>
+    <Optimize>true</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -132,7 +132,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <StartAction>Program</StartAction>
     <StartProgram>C:\Program Files\Rhino 6\System\Rhino.exe</StartProgram>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/PumaGrasshopper/PumaGrasshopper.csproj
+++ b/PumaGrasshopper/PumaGrasshopper.csproj
@@ -58,7 +58,7 @@
   <ItemGroup>
     <Compile Include="Annotations.cs" />
     <Compile Include="AnnotationSerialization.cs" />
-    <Compile Include="DefaultValuesMap.cs" />
+    <Compile Include="AttributesValuesMap.cs" />
     <Compile Include="ComponentPuma.cs" />
     <Compile Include="ComponentLibraryInfo.cs" />
     <Compile Include="ComponentReportsDisplay.cs" />

--- a/PumaGrasshopper/PumaGrasshopper.csproj
+++ b/PumaGrasshopper/PumaGrasshopper.csproj
@@ -69,6 +69,7 @@
     <Compile Include="AttributeForm.Designer.cs">
       <DependentUpon>AttributeForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="InteropWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
@@ -79,6 +80,7 @@
     <Compile Include="PumaUIDs.cs" />
     <Compile Include="ReportAttribute.cs" />
     <Compile Include="RuleAttribute.cs" />
+    <Compile Include="RuleAttributesMap.cs" />
     <Compile Include="RulePackageParam.cs" />
     <Compile Include="SerializationIDs.cs" />
     <Compile Include="Utils.cs" />

--- a/PumaGrasshopper/PumaGrasshopper.csproj
+++ b/PumaGrasshopper/PumaGrasshopper.csproj
@@ -29,7 +29,7 @@
     <TargetExt>.gha</TargetExt>
     <OutputPath>..\build\</OutputPath>
     <PlatformTarget>x64</PlatformTarget>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -131,8 +131,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <StartAction>Program</StartAction>
     <StartProgram>C:\Program Files\Rhino 6\System\Rhino.exe</StartProgram>
-    <DefineConstants>
-    </DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/PumaGrasshopper/PumaGrasshopper.csproj
+++ b/PumaGrasshopper/PumaGrasshopper.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <Compile Include="Annotations.cs" />
     <Compile Include="AnnotationSerialization.cs" />
+    <Compile Include="DefaultValuesMap.cs" />
     <Compile Include="ComponentPuma.cs" />
     <Compile Include="ComponentLibraryInfo.cs" />
     <Compile Include="ComponentReportsDisplay.cs" />

--- a/PumaGrasshopper/RuleAttribute.cs
+++ b/PumaGrasshopper/RuleAttribute.cs
@@ -44,7 +44,7 @@ namespace PumaGrasshopper
             this.mGroup = group;
         }
 
-        public IGH_Param CreateInputParameter(DefaultValuesMap[] defaultValuesMap)
+        public IGH_Param CreateInputParameter(AttributesValuesMap[] defaultValuesMap)
         {
             switch (this.mAttribType)
             {
@@ -59,7 +59,7 @@ namespace PumaGrasshopper
                             Optional = true,
                             Access = GetAccess()
                         };
-                        param_bool.SetPersistentData(DefaultValuesMap.GetDefaultBooleans(mFullName, defaultValuesMap, IsArray()));
+                        param_bool.SetPersistentData(AttributesValuesMap.GetDefaultBooleans(mFullName, defaultValuesMap, IsArray()));
 
                         return param_bool;
                     }
@@ -75,7 +75,7 @@ namespace PumaGrasshopper
                             Optional = true,
                             Access = GetAccess()
                         };
-                        param_number.SetPersistentData(DefaultValuesMap.GetDefaultDoubles(mFullName, defaultValuesMap, IsArray()));
+                        param_number.SetPersistentData(AttributesValuesMap.GetDefaultDoubles(mFullName, defaultValuesMap, IsArray()));
                         
                         return param_number;
                     }
@@ -93,7 +93,7 @@ namespace PumaGrasshopper
                                 Optional = true,
                                 Access = GetAccess()
                             };
-                            param_color.SetPersistentData(DefaultValuesMap.GetDefaultColors(mFullName, defaultValuesMap));
+                            param_color.SetPersistentData(AttributesValuesMap.GetDefaultColors(mFullName, defaultValuesMap));
                             return param_color;
                         }
                         else
@@ -106,7 +106,7 @@ namespace PumaGrasshopper
                                 Optional = true,
                                 Access = GetAccess()
                             };
-                            param_str.SetPersistentData(DefaultValuesMap.GetDefaultStrings(mFullName, defaultValuesMap, IsArray()));
+                            param_str.SetPersistentData(AttributesValuesMap.GetDefaultStrings(mFullName, defaultValuesMap, IsArray()));
                             return param_str;
                         }
                     }

--- a/PumaGrasshopper/RuleAttribute.cs
+++ b/PumaGrasshopper/RuleAttribute.cs
@@ -44,7 +44,7 @@ namespace PumaGrasshopper
             this.mGroup = group;
         }
 
-        public IGH_Param CreateInputParameter()
+        public IGH_Param CreateInputParameter(DefaultValuesMap[] defaultValuesMap)
         {
             switch (this.mAttribType)
             {
@@ -59,6 +59,7 @@ namespace PumaGrasshopper
                             Optional = true,
                             Access = GetAccess()
                         };
+                        param_bool.SetPersistentData(DefaultValuesMap.GetDefaultBooleans(mFullName, defaultValuesMap, IsArray()));
 
                         return param_bool;
                     }
@@ -74,6 +75,7 @@ namespace PumaGrasshopper
                             Optional = true,
                             Access = GetAccess()
                         };
+                        param_number.SetPersistentData(DefaultValuesMap.GetDefaultDoubles(mFullName, defaultValuesMap, IsArray()));
                         
                         return param_number;
                     }
@@ -91,6 +93,7 @@ namespace PumaGrasshopper
                                 Optional = true,
                                 Access = GetAccess()
                             };
+                            param_color.SetPersistentData(DefaultValuesMap.GetDefaultColors(mFullName, defaultValuesMap));
                             return param_color;
                         }
                         else
@@ -103,6 +106,7 @@ namespace PumaGrasshopper
                                 Optional = true,
                                 Access = GetAccess()
                             };
+                            param_str.SetPersistentData(DefaultValuesMap.GetDefaultStrings(mFullName, defaultValuesMap, IsArray()));
                             return param_str;
                         }
                     }

--- a/PumaGrasshopper/RuleAttributesMap.cs
+++ b/PumaGrasshopper/RuleAttributesMap.cs
@@ -8,35 +8,28 @@ namespace PumaGrasshopper
 {
     public class RuleAttributesMap
     {
-        private List<int> boolStarts;
-        private List<int> doubleStarts;
-        private List<int> stringStarts;
-        private List<int> boolArrayStarts;
-        private List<int> doubleArrayStarts;
-        private List<int> stringArrayStarts;
+        private List<int> boolStarts = new List<int>();
+        private List<int> doubleStarts = new List<int>();
+        private List<int> stringStarts = new List<int>();
+        private List<int> boolArrayStarts = new List<int>();
+        private List<int> doubleArrayStarts = new List<int>();
+        private List<int> stringArrayStarts = new List<int>();
 
-        public List<string> boolKeys;
-        public List<string> doubleKeys;
-        public List<string> stringKeys;
-        public List<string> boolArrayKeys;
-        public List<string> doubleArrayKeys;
-        public List<string> stringArrayKeys;
+        public List<string> boolKeys = new List<string>();
+        public List<string> doubleKeys = new List<string>();
+        public List<string> stringKeys = new List<string>();
+        public List<string> boolArrayKeys = new List<string>();
+        public List<string> doubleArrayKeys = new List<string>();
+        public List<string> stringArrayKeys = new List<string>();
 
-        public List<bool> boolValues;
-        public List<double> doubleValues;
-        public List<string> stringValues;
-        public List<string> boolArrayValues;
-        public List<string> doubleArrayValues;
-        public List<string> stringArrayValues;
+        public List<bool> boolValues = new List<bool>();
+        public List<double> doubleValues = new List<double>();
+        public List<string> stringValues = new List<string>();
+        public List<string> boolArrayValues = new List<string>();
+        public List<string> doubleArrayValues = new List<string>();
+        public List<string> stringArrayValues = new List<string>();
 
-        public RuleAttributesMap() {
-            boolStarts = new List<int>();
-            doubleStarts = new List<int>();
-            stringStarts = new List<int>();
-            boolArrayStarts = new List<int>();
-            doubleArrayStarts = new List<int>();
-            stringArrayStarts = new List<int>();
-        }
+        public RuleAttributesMap() { }
 
         public void StartShape()
         {

--- a/PumaGrasshopper/RuleAttributesMap.cs
+++ b/PumaGrasshopper/RuleAttributesMap.cs
@@ -29,7 +29,14 @@ namespace PumaGrasshopper
         public List<string> doubleArrayValues;
         public List<string> stringArrayValues;
 
-        public RuleAttributesMap() { }
+        public RuleAttributesMap() {
+            boolStarts = new List<int>();
+            doubleStarts = new List<int>();
+            stringStarts = new List<int>();
+            boolArrayStarts = new List<int>();
+            doubleArrayStarts = new List<int>();
+            stringArrayStarts = new List<int>();
+        }
 
         public void StartShape()
         {

--- a/PumaGrasshopper/RuleAttributesMap.cs
+++ b/PumaGrasshopper/RuleAttributesMap.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PumaGrasshopper
+{
+    public class RuleAttributesMap
+    {
+        private List<int> boolStarts;
+        private List<int> doubleStarts;
+        private List<int> stringStarts;
+        private List<int> boolArrayStarts;
+        private List<int> doubleArrayStarts;
+        private List<int> stringArrayStarts;
+
+        public List<string> boolKeys;
+        public List<string> doubleKeys;
+        public List<string> stringKeys;
+        public List<string> boolArrayKeys;
+        public List<string> doubleArrayKeys;
+        public List<string> stringArrayKeys;
+
+        public List<bool> boolValues;
+        public List<double> doubleValues;
+        public List<string> stringValues;
+        public List<string> boolArrayValues;
+        public List<string> doubleArrayValues;
+        public List<string> stringArrayValues;
+
+        public RuleAttributesMap() { }
+
+        public void StartShape()
+        {
+            boolStarts.Add(boolKeys.Count);
+            doubleStarts.Add(doubleKeys.Count);
+            stringStarts.Add(stringKeys.Count);
+            boolArrayStarts.Add(boolArrayKeys.Count);
+            doubleArrayStarts.Add(doubleArrayKeys.Count);
+            stringArrayStarts.Add(stringArrayKeys.Count);
+        }
+
+        public void AddDouble(string key, double value)
+        {
+            doubleKeys.Add(key);
+            doubleValues.Add(value);
+        }
+
+        public void AddString(string key, string value)
+        {
+            stringKeys.Add(key);
+            stringValues.Add(value);
+        }
+
+        public void AddBoolean(string key, bool value)
+        {
+            boolKeys.Add(key);
+            boolValues.Add(value);
+        }
+
+        public void AddBoolArray(string key, bool[] values)
+        {
+            boolArrayKeys.Add(key);
+            boolArrayValues.Add(Utils.ToCeArray(values));
+        }
+
+        public void AddDoubleArray(string key, double[] values)
+        {
+            doubleArrayKeys.Add(key);
+            doubleArrayValues.Add(Utils.ToCeArray(values));
+        }
+
+        public void AddStringArray(string key, string[] values)
+        {
+            stringArrayKeys.Add(key);
+            stringArrayValues.Add(Utils.ToCeArray(values));
+        }
+
+        public int[] GetStringStarts() => stringStarts.ToArray();
+        public int[] GetBoolStarts() => boolStarts.ToArray();
+        public int[] GetDoubleStarts() => doubleStarts.ToArray();
+
+        public int[] GetStringArrayStarts() => stringArrayStarts.ToArray();
+        public int[] GetDoubleArrayStarts() => doubleArrayStarts.ToArray();
+        public int[] GetBoolArrayStarts() => boolArrayStarts.ToArray();
+    }
+}

--- a/PumaGrasshopper/RuleAttributesMap.cs
+++ b/PumaGrasshopper/RuleAttributesMap.cs
@@ -31,7 +31,7 @@ namespace PumaGrasshopper
 
         public RuleAttributesMap() { }
 
-        public void StartShape()
+        public void StartNewSection()
         {
             boolStarts.Add(boolKeys.Count);
             doubleStarts.Add(doubleKeys.Count);

--- a/PumaGrasshopper/Utils.cs
+++ b/PumaGrasshopper/Utils.cs
@@ -125,6 +125,10 @@ namespace PumaGrasshopper
             return values.Aggregate("", (acc, x) => acc + x.ToString()) + ":";
         }
 
+        public static string[] StringFromCeArray(string values) => values.Split(':');
+        public static bool[] BoolFromCeArray(string values) => Array.ConvertAll(values.Split(':'), value => Convert.ToBoolean(value));
+        public static double[] DoubleFromCeArray(string values) => Array.ConvertAll(values.Split(':'), value => Convert.ToDouble(value));
+
         public static GH_Structure<GH_Number> FromListToTree(List<double> valueList)
         {
             GH_Structure<GH_Number> tree = new GH_Structure<GH_Number>();

--- a/PumaGrasshopper/Utils.cs
+++ b/PumaGrasshopper/Utils.cs
@@ -31,12 +31,55 @@ using System.Drawing;
 using Grasshopper.Kernel.Data;
 using System.Xml.Serialization;
 using System.IO;
+using Rhino.Geometry;
 
 namespace PumaGrasshopper
 {
 
     class Utils
     {
+        public static GH_Structure<GH_Mesh> CreateMeshStructure(List<Mesh[]> generatedMeshes)
+        {
+            // GH_Structure is the data tree outputed by our component, it takes only GH_Mesh (which is a grasshopper wrapper class over the rhino Mesh), 
+            // thus a conversion is necessary when adding Meshes.
+            GH_Structure<GH_Mesh> mesh_struct = new GH_Structure<GH_Mesh>();
+
+            for (int shapeId = 0; shapeId < generatedMeshes.Count; shapeId++)
+            {
+                if (generatedMeshes[shapeId] == null)
+                    continue;
+
+                GH_Path path = new GH_Path(shapeId);
+                var meshBundle = generatedMeshes[shapeId];
+                foreach (var mesh in meshBundle)
+                {
+                    GH_Mesh gh_mesh = null;
+                    var status = GH_Convert.ToGHMesh(mesh, GH_Conversion.Both, ref gh_mesh);
+                    if (status)
+                    {
+                        mesh_struct.Append(gh_mesh, path);
+                    }
+                }
+            }
+
+            return mesh_struct;
+        }
+
+        public static GH_Structure<GH_Material> CreateMaterialStructure(List<GH_Material[]> materials)
+        {
+            GH_Structure<GH_Material> material_struct = new GH_Structure<GH_Material>();
+
+            int index = 0;
+            materials.ForEach((material) =>
+            {
+                GH_Path path = new GH_Path(index);
+                material_struct.AppendRange(material, path);
+                index++;
+            });
+
+            return material_struct;
+        }
+
         public static IntPtr CreateIntArrayPtr(int size)
         {
             return Marshal.AllocCoTaskMem(Marshal.SizeOf(typeof(int)) * size);

--- a/PumaGrasshopper/Utils.cs
+++ b/PumaGrasshopper/Utils.cs
@@ -77,6 +77,11 @@ namespace PumaGrasshopper
             return array;
         }
 
+        public static string ToCeArray<T>(T[] values)
+        {
+            return values.Aggregate("", (acc, x) => acc + x.ToString()) + ":";
+        }
+
         public static GH_Structure<GH_Number> FromListToTree(List<double> valueList)
         {
             GH_Structure<GH_Number> tree = new GH_Structure<GH_Number>();

--- a/PumaRhino/CCommandApplyRulePackage.cpp
+++ b/PumaRhino/CCommandApplyRulePackage.cpp
@@ -141,13 +141,10 @@ CRhinoCommand::result CCommandApplyRulePackage::RunCommand(const CRhinoCommandCo
 		return failure;
 	}
 
-	RhinoPRT::get().ClearInitialShapes();
-
 	std::vector<RawInitialShape> rawInitialShapes;
 	rawInitialShapes.reserve(mesh_array.Count());
 	for (int i = 0; i < mesh_array.Count(); ++i)
 		rawInitialShapes.emplace_back(*mesh_array[i]);
-	RhinoPRT::get().SetInitialShapes(rawInitialShapes);
 
 	// Initialise the attribute map builders for each initial shape.
 	pcu::AttributeMapBuilderVector aBuilders(mesh_array.Count());

--- a/PumaRhino/CCommandApplyRulePackage.cpp
+++ b/PumaRhino/CCommandApplyRulePackage.cpp
@@ -141,14 +141,6 @@ CRhinoCommand::result CCommandApplyRulePackage::RunCommand(const CRhinoCommandCo
 		return failure;
 	}
 
-	try {
-		RhinoPRT::get().SetRPKPath(rpk);
-	}
-	catch (std::exception& e) {
-		LOG_ERR << "Failed to set Rule Packages: " << e.what();
-		return CRhinoCommand::failure;
-	}
-
 	RhinoPRT::get().ClearInitialShapes();
 
 	std::vector<RawInitialShape> rawInitialShapes;
@@ -157,12 +149,14 @@ CRhinoCommand::result CCommandApplyRulePackage::RunCommand(const CRhinoCommandCo
 		rawInitialShapes.emplace_back(*mesh_array[i]);
 	RhinoPRT::get().SetInitialShapes(rawInitialShapes);
 
-	// PRT Generation
-	bool status = RhinoPRT::get().GenerateGeometry();
-	if (!status)
-		return CRhinoCommand::failure;
+	// Initialise the attribute map builders for each initial shape.
+	pcu::AttributeMapBuilderVector aBuilders(mesh_array.Count());
+	for (auto& it : aBuilders) {
+		it.reset(prt::AttributeMapBuilder::create());
+	}
 
-	const auto& generated_models = RhinoPRT::get().getGenModels();
+	// PRT Generation
+	const auto& generated_models = RhinoPRT::get().GenerateGeometry(rpk, rawInitialShapes, aBuilders);
 
 	// Add the objects to the Rhino scene.
 	for (size_t initialShapeIndex = 0; initialShapeIndex < generated_models.size(); initialShapeIndex++) {

--- a/PumaRhino/ModelGenerator.cpp
+++ b/PumaRhino/ModelGenerator.cpp
@@ -176,25 +176,12 @@ ModelGenerator::ModelGenerator() {
 }
 
 pcu::ResolveMapSPtr ModelGenerator::getResolveMap(const std::wstring& rulePkg) {
-	pcu::ResolveMapSPtr resolveMap;
-	try {
-		const ResolveMap::ResolveMapCache::LookupResult lookup = PRTContext::get()->getResolveMap(rulePkg);
-		resolveMap = lookup.first;
-	}
-	catch (std::exception&) {
-		throw;
-	}
-	return resolveMap;
+	const ResolveMap::ResolveMapCache::LookupResult lookup = PRTContext::get()->getResolveMap(rulePkg);
+	return lookup.first;
 }
 
 const RuleAttributes ModelGenerator::getRuleAttributes(const std::wstring& rulePkg) {
-	pcu::ResolveMapSPtr resolveMap;
-	try {
-		resolveMap = getResolveMap(rulePkg);
-	}
-	catch (std::exception&) {
-		throw;
-	}
+	pcu::ResolveMapSPtr resolveMap = getResolveMap(rulePkg);
 
 	// Extract the rule package info.
 	std::wstring ruleFile = pcu::getRuleFileEntry(resolveMap);

--- a/PumaRhino/ModelGenerator.cpp
+++ b/PumaRhino/ModelGenerator.cpp
@@ -175,7 +175,7 @@ ModelGenerator::ModelGenerator() {
 	mCGAPrintOptions = pcu::createValidatedOptions(ENCODER_ID_CGA_PRINT, printOptions.get());
 }
 
-pcu::ShapeAttributes ModelGenerator::getShapeAttributes(const std::wstring& rulePkg) {
+pcu::ResolveMapSPtr ModelGenerator::getResolveMap(const std::wstring& rulePkg) {
 	pcu::ResolveMapSPtr resolveMap;
 	try {
 		const ResolveMap::ResolveMapCache::LookupResult lookup = PRTContext::get()->getResolveMap(rulePkg);
@@ -184,19 +184,30 @@ pcu::ShapeAttributes ModelGenerator::getShapeAttributes(const std::wstring& rule
 	catch (std::exception&) {
 		throw;
 	}
+	return resolveMap;
+}
+
+pcu::ShapeAttributes ModelGenerator::getShapeAttributes(const std::wstring& rulePkg) {
+	pcu::ResolveMapSPtr resolveMap;
+	try {
+		resolveMap = getResolveMap(rulePkg);
+	}
+	catch (std::exception&) {
+		throw;
+	}
 
 	// Extract the rule package info.
 	std::wstring ruleFile = pcu::getRuleFileEntry(resolveMap);
 	if (ruleFile.empty()) {
-		LOG_ERR << "Could not find rule file in rule package " << rulePkg;
-		return;
+		LOG_ERR << "Could not find rule file in rule package" << rulePkg;
+		throw std::exception("Could not find rule file in rule package ");
 	}
 
 	// To create the ruleFileInfo, we first need the ruleFileURI
 	const wchar_t* ruleFileURI = resolveMap->getString(ruleFile.c_str());
 	if (ruleFileURI == nullptr) {
-		LOG_ERR << "Could not find rule file URI in resolve map of rule package " << rulePkg;
-		return;
+		LOG_ERR << "Could not find rule file URI in resolve map of rule package." << rulePkg;
+		throw std::exception("Could not find rule file URI in resolve map of rule package.");
 	}
 
 	// Create RuleFileInfo
@@ -205,7 +216,7 @@ pcu::ShapeAttributes ModelGenerator::getShapeAttributes(const std::wstring& rule
 	        pcu::RuleFileInfoPtr(prt::createRuleFileInfo(ruleFileURI, PRTContext::get()->mPRTCache.get(), &infoStatus));
 	if (!ruleFileInfo || infoStatus != prt::STATUS_OK) {
 		LOG_ERR << "could not get rule file info from rule file " << ruleFile;
-		return;
+		throw std::exception("Could not get rule file info from rule file.");
 	}
 
 	std::wstring startRule = pcu::detectStartRule(ruleFileInfo);
@@ -213,62 +224,8 @@ pcu::ShapeAttributes ModelGenerator::getShapeAttributes(const std::wstring& rule
 	return pcu::ShapeAttributes(ruleFileInfo, ruleFile, startRule);
 }
 
-void ModelGenerator::updateRuleFiles(const std::wstring& rulePkg) {
-	mCurrentRPK = rulePkg;
-
-	try {
-		const ResolveMap::ResolveMapCache::LookupResult lookup = PRTContext::get()->getResolveMap(rulePkg);
-		if (lookup.second == ResolveMap::ResolveMapCache::CacheStatus::HIT && rulePkg == mRulePkg) {
-			// resolvemap already exists and the rule file was not changed, no need to update.
-			return;
-		}
-		mResolveMap = lookup.first;
-	}
-	catch (std::exception&) {
-		mResolveMap.reset();
-		mRuleFile.clear();
-		mStartRule.clear();
-		mRuleAttributes.clear();
-		throw;
-	}
-
-	// Cache miss -> initialize everything
-	// Reset the rule infos
-	mRuleAttributes.clear();
-	mRuleFile.clear();
-	mStartRule.clear();
-	mRulePkg = rulePkg;
-
-	// Extract the rule package info.
-	mRuleFile = pcu::getRuleFileEntry(mResolveMap);
-	if (mRuleFile.empty()) {
-		LOG_ERR << "Could not find rule file in rule package " << mRulePkg;
-		return;
-	}
-
-	// To create the ruleFileInfo, we first need the ruleFileURI
-	const wchar_t* ruleFileURI = mResolveMap->getString(mRuleFile.c_str());
-	if (ruleFileURI == nullptr) {
-		LOG_ERR << "Could not find rule file URI in resolve map of rule package " << mRulePkg;
-		return;
-	}
-
-	// Create RuleFileInfo
-	prt::Status infoStatus = prt::STATUS_UNSPECIFIED_ERROR;
-	mRuleFileInfo =
-	        pcu::RuleFileInfoPtr(prt::createRuleFileInfo(ruleFileURI, PRTContext::get()->mPRTCache.get(), &infoStatus));
-	if (!mRuleFileInfo || infoStatus != prt::STATUS_OK) {
-		LOG_ERR << "could not get rule file info from rule file " << mRuleFile;
-		return;
-	}
-
-	mStartRule = pcu::detectStartRule(mRuleFileInfo);
-
-	// Fill the list of rule attributes
-	createRuleAttributes(mRuleFile, *mRuleFileInfo.get(), mRuleAttributes);
-}
-
-bool ModelGenerator::evalDefaultAttributes(const std::vector<RawInitialShape>& rawInitialShapes,
+bool ModelGenerator::evalDefaultAttributes(pcu::ResolveMapSPtr& resolveMap,
+										   const std::vector<RawInitialShape>& rawInitialShapes,
                                            std::vector<pcu::ShapeAttributes>& shapeAttributes) {
 	// setup encoder options for attribute evaluation encoder
 	constexpr const wchar_t* encs[] = {ENCODER_ID_CGA_EVALATTR};
@@ -288,12 +245,12 @@ bool ModelGenerator::evalDefaultAttributes(const std::vector<RawInitialShape>& r
 
 	std::vector<pcu::InitialShapePtr> initialShapes;
 	std::vector<pcu::AttributeMapPtr> initialShapeAttributes; // put here to ensure same life time as initialShapes
-	if (!createInitialShapes(rawInitialShapes, shapeAttributes, attribMapBuilders, initialShapes,
+	if (!createInitialShapes(resolveMap, rawInitialShapes, shapeAttributes, attribMapBuilders, initialShapes,
 	                         initialShapeAttributes))
 		return false;
 
 	// run generate
-	AttrEvalCallbacks aec(attribMapBuilders, mRuleFileInfo);
+	AttrEvalCallbacks aec(attribMapBuilders, shapeAttributes.front().ruleFileInfo); // TODO: What if rule file info is not the same for all shapes?
 	const std::vector<prt::InitialShape const*> rawInitialShapePtrs = toRawPtrs<const prt::InitialShape>(initialShapes);
 	const prt::Status status = prt::generate(rawInitialShapePtrs.data(), rawInitialShapePtrs.size(), nullptr, encs,
 	                                         encsCount, encsOpts, &aec, PRTContext::get()->mPRTCache.get(), nullptr);
@@ -304,11 +261,13 @@ bool ModelGenerator::evalDefaultAttributes(const std::vector<RawInitialShape>& r
 	}
 
 	mDefaultValuesMap = createAttributeMaps(attribMapBuilders);
-
+	// TODO: return the default values back to Puma component.
 	return true;
 }
 
-bool ModelGenerator::createInitialShapes(const std::vector<RawInitialShape>& rawInitialShapes,
+bool ModelGenerator::createInitialShapes(
+	pcu::ResolveMapSPtr& resolveMap,
+	const std::vector<RawInitialShape>& rawInitialShapes,
                                          const std::vector<pcu::ShapeAttributes>& shapeAttributes,
                                          pcu::AttributeMapBuilderVector& aBuilders,
                                          std::vector<pcu::InitialShapePtr>& initialShapes,
@@ -329,20 +288,17 @@ bool ModelGenerator::createInitialShapes(const std::vector<RawInitialShape>& raw
 			return false;
 		}
 
-		// TODO: is this check necessary?
-		pcu::ShapeAttributes shapeAttr = (shapeAttributes.size() > i) ? shapeAttributes[0] : shapeAttributes[i];
-
 		// Set to default values
-		std::wstring ruleF = shapeAttr.ruleFile;
-		std::wstring startR = shapeAttr.startRule;
-		int32_t randomS = shapeAttr.seed;
-		std::wstring shapeN = shapeAttr.shapeName;
+		std::wstring ruleF = shapeAttributes[i].ruleFile;
+		std::wstring startR = shapeAttributes[i].startRule;
+		int32_t randomS = shapeAttributes[i].seed;
+		std::wstring shapeN = shapeAttributes[i].shapeName;
 
 		pcu::AttributeMapPtr initialShapeAttributes;
-		extractMainShapeAttributes(aBuilders[i], shapeAttr, ruleF, startR, randomS, shapeN, initialShapeAttributes);
+		extractMainShapeAttributes(aBuilders[i], shapeAttributes[i], ruleF, startR, randomS, shapeN, initialShapeAttributes);
 
 		const prt::Status attributeStatus = isb->setAttributes(ruleF.c_str(), startR.c_str(), randomS, shapeN.c_str(),
-		                                                       initialShapeAttributes.get(), mResolveMap.get());
+		                                                       initialShapeAttributes.get(), resolveMap.get());
 		if (attributeStatus != prt::STATUS_OK) {
 			LOG_ERR << "Failed to set initial shape attributes: " << prt::getStatusDescription(attributeStatus);
 			return false;
@@ -362,7 +318,8 @@ bool ModelGenerator::createInitialShapes(const std::vector<RawInitialShape>& raw
 	return true;
 }
 
-std::vector<GeneratedModelPtr> ModelGenerator::generateModel(const std::vector<RawInitialShape>& rawInitialShapes,
+std::vector<GeneratedModelPtr> ModelGenerator::generateModel(const std::wstring& rulePkg,
+															 const std::vector<RawInitialShape>& rawInitialShapes,
                                                              const std::vector<pcu::ShapeAttributes>& shapeAttributes,
                                                              pcu::AttributeMapBuilderVector& aBuilders) {
 	if ((shapeAttributes.size() != 1) && (shapeAttributes.size() < rawInitialShapes.size())) {
@@ -373,10 +330,12 @@ std::vector<GeneratedModelPtr> ModelGenerator::generateModel(const std::vector<R
 		LOG_WRN << "Number of shape attributes dictionaries defined greater than number of initial shapes given.";
 	}
 
+	pcu::ResolveMapSPtr resolveMap = getResolveMap(rulePkg);
+
 	try {
 		std::vector<pcu::InitialShapePtr> initialShapes;
 		std::vector<pcu::AttributeMapPtr> initialShapeAttributes; // put here to ensure same life time as initialShapes
-		if (!createInitialShapes(rawInitialShapes, shapeAttributes, aBuilders, initialShapes, initialShapeAttributes))
+		if (!createInitialShapes(resolveMap, rawInitialShapes, shapeAttributes, aBuilders, initialShapes, initialShapeAttributes))
 			return {};
 
 		const std::vector<const prt::AttributeMap*> encoderOptions = {mRhinoEncoderOptions.get(),

--- a/PumaRhino/ModelGenerator.cpp
+++ b/PumaRhino/ModelGenerator.cpp
@@ -377,17 +377,6 @@ void ModelGenerator::extractMainShapeAttributes(pcu::AttributeMapBuilderPtr& aBu
 	}
 }
 
-/*
-std::wstring ModelGenerator::getRuleFile() {
-	return this->mRuleFile;
-}
-std::wstring ModelGenerator::getStartingRule() {
-	return this->mStartRule;
-};
-std::wstring ModelGenerator::getDefaultShapeName() {
-	return this->mShapeName;
-};*/
-
 bool ModelGenerator::getDefaultValuesBoolean(const std::wstring& key, ON_SimpleArray<int>* pValues) {
 	if (mDefaultValuesMap.empty())
 		return false;

--- a/PumaRhino/ModelGenerator.h
+++ b/PumaRhino/ModelGenerator.h
@@ -41,7 +41,8 @@ public:
 	                                             const pcu::ShapeAttributes& shapeAttributes,
 	                                             pcu::AttributeMapBuilderVector& aBuilders);
 
-	bool evalDefaultAttributes(const std::wstring& rulePkg, const std::vector<RawInitialShape>& rawInitialShapes,
+	pcu::AttributeMapPtrVector evalDefaultAttributes(const std::wstring& rulePkg,
+	                                                 const std::vector<RawInitialShape>& rawInitialShapes,
 	                           pcu::ShapeAttributes& shapeAttributes);
 
 	pcu::ShapeAttributes getShapeAttributes(const std::wstring& rulePkg);
@@ -50,32 +51,11 @@ public:
 
 	const RuleAttributes getRuleAttributes(const std::wstring& rulePkg);
 
-	std::wstring getRuleFile();
-	std::wstring getStartingRule();
-	std::wstring getDefaultShapeName();
-
-	const pcu::AttributeMapPtrVector& getDefaultValueAttributeMap() {
-		return mDefaultValuesMap;
-	};
-
-	bool getDefaultValuesBoolean(const std::wstring& key, ON_SimpleArray<int>* pValues);
-	bool getDefaultValuesNumber(const std::wstring& key, ON_SimpleArray<double>* pValues);
-	bool getDefaultValuesText(const std::wstring& key, ON_ClassArray<ON_wString>* pTexts);
-	bool getDefaultValuesBooleanArray(const std::wstring& key, ON_SimpleArray<int>* pValues,
-	                                  ON_SimpleArray<int>* pSizes);
-	bool getDefaultValuesNumberArray(const std::wstring& key, ON_SimpleArray<double>* pValues,
-	                                 ON_SimpleArray<int>* pSizes);
-	bool getDefaultValuesTextArray(const std::wstring& key, ON_ClassArray<ON_wString>* pTexts,
-	                               ON_SimpleArray<int>* pSizes);
-
 private:
 
 	pcu::AttributeMapPtr mRhinoEncoderOptions;
 	pcu::AttributeMapPtr mCGAErrorOptions;
 	pcu::AttributeMapPtr mCGAPrintOptions;
-
-	// contains the rule attributes evaluated
-	pcu::AttributeMapPtrVector mDefaultValuesMap; //TODO remove from state
 
 	bool createInitialShapes(pcu::ResolveMapSPtr& resolveMap,
 							 const std::vector<RawInitialShape>& rawInitialShapes,

--- a/PumaRhino/ModelGenerator.h
+++ b/PumaRhino/ModelGenerator.h
@@ -41,7 +41,7 @@ public:
 	                                             const pcu::ShapeAttributes& shapeAttributes,
 	                                             pcu::AttributeMapBuilderVector& aBuilders);
 
-	bool evalDefaultAttributes(pcu::ResolveMapSPtr& resolveMap, const std::vector<RawInitialShape>& rawInitialShapes,
+	bool evalDefaultAttributes(const std::wstring& rulePkg, const std::vector<RawInitialShape>& rawInitialShapes,
 	                           pcu::ShapeAttributes& shapeAttributes);
 
 	pcu::ShapeAttributes getShapeAttributes(const std::wstring& rulePkg);
@@ -51,6 +51,7 @@ public:
 	const RuleAttributes& getRuleAttributes() const {
 		return mRuleAttributes;
 	}
+	const RuleAttributes getRuleAttributes(const std::wstring& rulePkg);
 
 	std::wstring getRuleFile();
 	std::wstring getStartingRule();

--- a/PumaRhino/ModelGenerator.h
+++ b/PumaRhino/ModelGenerator.h
@@ -38,11 +38,11 @@ public:
 
 	std::vector<GeneratedModelPtr> generateModel(const std::wstring& rulePkg,
 	                                             const std::vector<RawInitialShape>& rawInitialShapes,
-	                                             const std::vector<pcu::ShapeAttributes>& shapeAttributes,
+	                                             const pcu::ShapeAttributes& shapeAttributes,
 	                                             pcu::AttributeMapBuilderVector& aBuilders);
 
 	bool evalDefaultAttributes(pcu::ResolveMapSPtr& resolveMap, const std::vector<RawInitialShape>& rawInitialShapes,
-	                           std::vector<pcu::ShapeAttributes>& shapeAttributes);
+	                           pcu::ShapeAttributes& shapeAttributes);
 
 	pcu::ShapeAttributes getShapeAttributes(const std::wstring& rulePkg);
 
@@ -82,7 +82,7 @@ private:
 
 	bool createInitialShapes(pcu::ResolveMapSPtr& resolveMap,
 							 const std::vector<RawInitialShape>& rawInitialShapes,
-	                         const std::vector<pcu::ShapeAttributes>& shapeAttributes,
+	                         const pcu::ShapeAttributes& shapeAttributes,
 	                         pcu::AttributeMapBuilderVector& aBuilders,
 	                         std::vector<pcu::InitialShapePtr>& initialShapes,
 	                         std::vector<pcu::AttributeMapPtr>& initialShapeAttributes) const;

--- a/PumaRhino/ModelGenerator.h
+++ b/PumaRhino/ModelGenerator.h
@@ -48,9 +48,6 @@ public:
 
 	void updateEncoderOptions(bool emitMaterials);
 
-	const RuleAttributes& getRuleAttributes() const {
-		return mRuleAttributes;
-	}
 	const RuleAttributes getRuleAttributes(const std::wstring& rulePkg);
 
 	std::wstring getRuleFile();
@@ -72,14 +69,13 @@ public:
 	                               ON_SimpleArray<int>* pSizes);
 
 private:
-	RuleAttributes mRuleAttributes; // TODO remove
 
 	pcu::AttributeMapPtr mRhinoEncoderOptions;
 	pcu::AttributeMapPtr mCGAErrorOptions;
 	pcu::AttributeMapPtr mCGAPrintOptions;
 
 	// contains the rule attributes evaluated
-	pcu::AttributeMapPtrVector mDefaultValuesMap;
+	pcu::AttributeMapPtrVector mDefaultValuesMap; //TODO remove from state
 
 	bool createInitialShapes(pcu::ResolveMapSPtr& resolveMap,
 							 const std::vector<RawInitialShape>& rawInitialShapes,

--- a/PumaRhino/ModelGenerator.h
+++ b/PumaRhino/ModelGenerator.h
@@ -34,14 +34,15 @@ class ModelGenerator {
 public:
 	ModelGenerator();
 
-	std::vector<GeneratedModelPtr> generateModel(const std::vector<RawInitialShape>& rawInitialShapes,
+	pcu::ResolveMapSPtr getResolveMap(const std::wstring& rulePkg);
+
+	std::vector<GeneratedModelPtr> generateModel(const std::wstring& rulePkg,
+	                                             const std::vector<RawInitialShape>& rawInitialShapes,
 	                                             const std::vector<pcu::ShapeAttributes>& shapeAttributes,
 	                                             pcu::AttributeMapBuilderVector& aBuilders);
 
-	bool evalDefaultAttributes(const std::vector<RawInitialShape>& rawInitialShapes,
+	bool evalDefaultAttributes(pcu::ResolveMapSPtr& resolveMap, const std::vector<RawInitialShape>& rawInitialShapes,
 	                           std::vector<pcu::ShapeAttributes>& shapeAttributes);
-
-	void updateRuleFiles(const std::wstring& rulePkg);
 
 	pcu::ShapeAttributes getShapeAttributes(const std::wstring& rulePkg);
 
@@ -54,16 +55,10 @@ public:
 	std::wstring getRuleFile();
 	std::wstring getStartingRule();
 	std::wstring getDefaultShapeName();
-	/* inline const prt::ResolveMap* getResolveMap() {
-		return mResolveMap.get();
-	};*/
+
 	const pcu::AttributeMapPtrVector& getDefaultValueAttributeMap() {
 		return mDefaultValuesMap;
 	};
-
-	/* const std::wstring getPackagePath() const {
-		return mCurrentRPK;
-	}*/
 
 	bool getDefaultValuesBoolean(const std::wstring& key, ON_SimpleArray<int>* pValues);
 	bool getDefaultValuesNumber(const std::wstring& key, ON_SimpleArray<double>* pValues);
@@ -76,9 +71,7 @@ public:
 	                               ON_SimpleArray<int>* pSizes);
 
 private:
-	//pcu::RuleFileInfoPtr mRuleFileInfo;
-	//pcu::ResolveMapSPtr mResolveMap;
-	RuleAttributes mRuleAttributes;
+	RuleAttributes mRuleAttributes; // TODO remove
 
 	pcu::AttributeMapPtr mRhinoEncoderOptions;
 	pcu::AttributeMapPtr mCGAErrorOptions;
@@ -87,14 +80,8 @@ private:
 	// contains the rule attributes evaluated
 	pcu::AttributeMapPtrVector mDefaultValuesMap;
 
-	//std::wstring mRulePkg;
-	//std::wstring mRuleFile = L"bin/rule.cgb";
-	//std::wstring mStartRule = L"default$Lot";
-	//int32_t mSeed = 0;
-	//std::wstring mShapeName = L"Lot";
-	//std::wstring mCurrentRPK;
-
-	bool createInitialShapes(const std::vector<RawInitialShape>& rawInitialShapes,
+	bool createInitialShapes(pcu::ResolveMapSPtr& resolveMap,
+							 const std::vector<RawInitialShape>& rawInitialShapes,
 	                         const std::vector<pcu::ShapeAttributes>& shapeAttributes,
 	                         pcu::AttributeMapBuilderVector& aBuilders,
 	                         std::vector<pcu::InitialShapePtr>& initialShapes,

--- a/PumaRhino/ModelGenerator.h
+++ b/PumaRhino/ModelGenerator.h
@@ -43,6 +43,8 @@ public:
 
 	void updateRuleFiles(const std::wstring& rulePkg);
 
+	pcu::ShapeAttributes getShapeAttributes(const std::wstring& rulePkg);
+
 	void updateEncoderOptions(bool emitMaterials);
 
 	const RuleAttributes& getRuleAttributes() const {
@@ -52,16 +54,16 @@ public:
 	std::wstring getRuleFile();
 	std::wstring getStartingRule();
 	std::wstring getDefaultShapeName();
-	inline const prt::ResolveMap* getResolveMap() {
+	/* inline const prt::ResolveMap* getResolveMap() {
 		return mResolveMap.get();
-	};
+	};*/
 	const pcu::AttributeMapPtrVector& getDefaultValueAttributeMap() {
 		return mDefaultValuesMap;
 	};
 
-	const std::wstring getPackagePath() const {
+	/* const std::wstring getPackagePath() const {
 		return mCurrentRPK;
-	}
+	}*/
 
 	bool getDefaultValuesBoolean(const std::wstring& key, ON_SimpleArray<int>* pValues);
 	bool getDefaultValuesNumber(const std::wstring& key, ON_SimpleArray<double>* pValues);
@@ -74,8 +76,8 @@ public:
 	                               ON_SimpleArray<int>* pSizes);
 
 private:
-	pcu::RuleFileInfoPtr mRuleFileInfo;
-	pcu::ResolveMapSPtr mResolveMap;
+	//pcu::RuleFileInfoPtr mRuleFileInfo;
+	//pcu::ResolveMapSPtr mResolveMap;
 	RuleAttributes mRuleAttributes;
 
 	pcu::AttributeMapPtr mRhinoEncoderOptions;
@@ -85,12 +87,12 @@ private:
 	// contains the rule attributes evaluated
 	pcu::AttributeMapPtrVector mDefaultValuesMap;
 
-	std::wstring mRulePkg;
-	std::wstring mRuleFile = L"bin/rule.cgb";
-	std::wstring mStartRule = L"default$Lot";
-	int32_t mSeed = 0;
-	std::wstring mShapeName = L"Lot";
-	std::wstring mCurrentRPK;
+	//std::wstring mRulePkg;
+	//std::wstring mRuleFile = L"bin/rule.cgb";
+	//std::wstring mStartRule = L"default$Lot";
+	//int32_t mSeed = 0;
+	//std::wstring mShapeName = L"Lot";
+	//std::wstring mCurrentRPK;
 
 	bool createInitialShapes(const std::vector<RawInitialShape>& rawInitialShapes,
 	                         const std::vector<pcu::ShapeAttributes>& shapeAttributes,

--- a/PumaRhino/PumaGrasshopperAPI.cpp
+++ b/PumaRhino/PumaGrasshopperAPI.cpp
@@ -260,7 +260,7 @@ RHINOPRT_API int GetRuleAttributes(const wchar_t* rpk_path, ON_ClassArray<ON_wSt
 		if (attribute->groups.size() > 0)
 			pAttributesBuffer->Append(ON_wString(attribute->groups.front().c_str()));
 		else
-			pAttributesBuffer->Append(ON_wString(L""));
+			pAttributesBuffer->Append({});
 
 		pAttributesTypes->Append(attribute->mType);
 		pAttributesTypes->Append(attribute->mAnnotations.size());

--- a/PumaRhino/PumaGrasshopperAPI.cpp
+++ b/PumaRhino/PumaGrasshopperAPI.cpp
@@ -117,15 +117,19 @@ RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
 		int indexStartDoubleArray = *pDoubleArrayStarts->At(i);
 		int indexStartStringArray = *pStringArrayStarts->At(i);
 
-		int boolAttrCount = (i < shapeCount - 1 ? *pBoolStarts->At(i + 1) : boolCount) - indexStartBool;
-		int doubleAttrCount = (i < shapeCount - 1 ? *pDoubleStarts->At(i + 1): doubleCount) - indexStartDouble;
-		int stringAttrCount = (i < shapeCount - 1 ? *pStringStarts->At(i + 1) : stringCount) - indexStartString;
-		int boolAttrArrayCount =
-		        (i < shapeCount - 1 ? *pBoolArrayStarts->At(i + 1) : boolArrayCount) - indexStartBoolArray;
-		int doubleAttrArrayCount =
-		        (i < shapeCount - 1 ? *pDoubleArrayStarts->At(i + 1) : doubleArrayCount) - indexStartDoubleArray;
-		int stringAttrArrayCount =
-		        (i < shapeCount - 1 ? *pStringArrayStarts->At(i + 1) : stringArrayCount) - indexStartStringArray;
+		int nextIndexStartBool = i < shapeCount - 1 ? *pBoolStarts->At(i + 1) : boolCount;
+		int nextIndexStartDouble = i < shapeCount - 1 ? *pDoubleStarts->At(i + 1) : doubleCount;
+		int nextIndexStartString = i < shapeCount - 1 ? *pStringStarts->At(i + 1) : stringCount;
+		int nextIndexStartBoolArray = i < shapeCount - 1 ? *pBoolArrayStarts->At(i + 1) : boolArrayCount;
+		int nextIndexStartDoubleArray = i < shapeCount - 1 ? *pDoubleArrayStarts->At(i + 1) : doubleArrayCount;
+		int nextIndexStartStringArray = i < shapeCount - 1 ? *pStringArrayStarts->At(i + 1) : stringArrayCount;
+
+		int boolAttrCount = nextIndexStartBool - indexStartBool;
+		int doubleAttrCount = nextIndexStartDouble - indexStartDouble;
+		int stringAttrCount = nextIndexStartString - indexStartString;
+		int boolAttrArrayCount = nextIndexStartBoolArray - indexStartBoolArray;
+		int doubleAttrArrayCount = nextIndexStartDoubleArray - indexStartDoubleArray;
+		int stringAttrArrayCount = nextIndexStartStringArray - indexStartStringArray;
 
 		pcu::unpackBoolAttributes(indexStartBool, boolAttrCount, pBoolKeys, pBoolVals, aBuilders[i]);
 		pcu::unpackDoubleAttributes(indexStartDouble, doubleAttrCount, pDoubleKeys, pDoubleVals, aBuilders[i]);

--- a/PumaRhino/PumaGrasshopperAPI.cpp
+++ b/PumaRhino/PumaGrasshopperAPI.cpp
@@ -56,44 +56,6 @@ RHINOPRT_API void ShutdownRhinoPRT() {
 	RhinoPRT::get().ShutdownRhinoPRT();
 }
 
-/*
-RHINOPRT_API void SetPackage(const wchar_t* rpk_path, ON_wString* errorMsg) {
-	assert(rpk_path != nullptr); // guaranteed by managed call site
-	try {
-		RhinoPRT::get().SetRPKPath(rpk_path);
-	}
-	catch (std::exception& e) {
-		*errorMsg += pcu::toUTF16FromOSNarrow(e.what()).c_str();
-	}
-}
-
-RHINOPRT_API bool GetPackagePath(ON_wString* pRpk) {
-	if (pRpk == nullptr)
-		return false;
-
-	const std::wstring rpk = RhinoPRT::get().GetRPKPath();
-	if (rpk.empty())
-		return false;
-
-	*pRpk += rpk.c_str();
-	return true;
-}
-
-inline RHINOPRT_API bool AddInitialMesh(ON_SimpleArray<const ON_Mesh*>* pMesh) {
-	if (pMesh == nullptr)
-		return false;
-
-	std::vector<RawInitialShape> rawInitialShapes;
-	rawInitialShapes.reserve(pMesh->Count());
-	for (int i = 0; i < pMesh->Count(); ++i) {
-		rawInitialShapes.emplace_back(**pMesh->At(i));
-	}
-
-	RhinoPRT::get().SetInitialShapes(rawInitialShapes);
-	return true;
-}
-*/
-
 RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
 						   // rule attributes
 						   const int shapeCount,

--- a/PumaRhino/PumaGrasshopperAPI.cpp
+++ b/PumaRhino/PumaGrasshopperAPI.cpp
@@ -33,6 +33,8 @@
 
 #define RHINOPRT_API __declspec(dllexport)
 
+constexpr bool DBG = false;
+
 namespace {
 
 template <typename T, typename T1>
@@ -117,12 +119,14 @@ RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
 		int indexStartDoubleArray = *pDoubleArrayStarts->At(i);
 		int indexStartStringArray = *pStringArrayStarts->At(i);
 
-		int nextIndexStartBool = i < shapeCount - 1 ? *pBoolStarts->At(i + 1) : boolCount;
-		int nextIndexStartDouble = i < shapeCount - 1 ? *pDoubleStarts->At(i + 1) : doubleCount;
-		int nextIndexStartString = i < shapeCount - 1 ? *pStringStarts->At(i + 1) : stringCount;
-		int nextIndexStartBoolArray = i < shapeCount - 1 ? *pBoolArrayStarts->At(i + 1) : boolArrayCount;
-		int nextIndexStartDoubleArray = i < shapeCount - 1 ? *pDoubleArrayStarts->At(i + 1) : doubleArrayCount;
-		int nextIndexStartStringArray = i < shapeCount - 1 ? *pStringArrayStarts->At(i + 1) : stringArrayCount;
+		bool notLastShape = i < shapeCount - 1;
+
+		int nextIndexStartBool = notLastShape ? *pBoolStarts->At(i + 1) : boolCount;
+		int nextIndexStartDouble = notLastShape ? *pDoubleStarts->At(i + 1) : doubleCount;
+		int nextIndexStartString = notLastShape ? *pStringStarts->At(i + 1) : stringCount;
+		int nextIndexStartBoolArray = notLastShape ? *pBoolArrayStarts->At(i + 1) : boolArrayCount;
+		int nextIndexStartDoubleArray = notLastShape ? *pDoubleArrayStarts->At(i + 1) : doubleArrayCount;
+		int nextIndexStartStringArray = notLastShape ? *pStringArrayStarts->At(i + 1) : stringArrayCount;
 
 		int boolAttrCount = nextIndexStartBool - indexStartBool;
 		int doubleAttrCount = nextIndexStartDouble - indexStartDouble;
@@ -176,9 +180,9 @@ RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
 
 				for (auto& texture : matAttributes.mTexturePaths) {
 
-#ifdef DEBUG
-					LOG_DBG << L"texture: [ " << texture.first << " : " << texture.second << "]";
-#endif // DEBUG
+					if constexpr (DBG) {
+						LOG_DBG << L"texture: [ " << texture.first << " : " << texture.second << "]";
+					}
 
 					pTexKeys->Append(ON_wString(texture.first.c_str()));
 					pTexPaths->Append(ON_wString(texture.second.c_str()));

--- a/PumaRhino/PumaGrasshopperAPI.cpp
+++ b/PumaRhino/PumaGrasshopperAPI.cpp
@@ -103,22 +103,22 @@ RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
 						   // rule attributes
 						   const int shapeCount,
 						   const int* pBoolStarts, const int boolCount,
-						   const wchar_t* pBoolKeys, const bool* pBoolVals,
+						   ON_ClassArray<ON_wString>* pBoolKeys, ON_SimpleArray<int>* pBoolVals,
 
 						   const int* pDoubleStarts, const int doubleCount,
-						   const wchar_t* pDoubleKeys, const double* pDoubleVals,
+						   ON_ClassArray<ON_wString>* pDoubleKeys, ON_SimpleArray<double>* pDoubleVals,
 
-						   const int* pStringStarts, const int stringCount,
-						   const wchar_t* pStringKeys, const wchar_t* pStringVals,
+						   const int* pStringStarts, const int stringCount, 
+						   ON_ClassArray<ON_wString>* pStringKeys, ON_ClassArray<ON_wString>* pStringVals,
 
 						   const int* pBoolArrayStarts, const int boolArrayCount,
-						   const wchar_t* pBoolArrayKeys, const bool** pBoolArrayVals,
+                           ON_ClassArray<ON_wString>* pBoolArrayKeys, ON_ClassArray<ON_wString>* pBoolArrayVals,
 
 						   const int* pDoubleArrayStarts, const int doubleArrayCount,
-						   const wchar_t* pDoubleArrayKeys, const float** pDoubleArrayVals,
+                           ON_ClassArray<ON_wString>* pDoubleArrayKeys, ON_ClassArray<ON_wString>* pDoubleArrayVals,
 
 						   const int* pStringArrayStarts, const int stringArrayCount,
-						   const wchar_t* pStringArrayKeys, const wchar_t** pStringArrayVals,
+                           ON_ClassArray<ON_wString>* pStringArrayKeys, ON_ClassArray<ON_wString>* pStringArrayVals,
 
 						   // Initial geometry
                            ON_SimpleArray<const ON_Mesh*>* pMesh,
@@ -160,9 +160,13 @@ RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
 
 		pcu::unpackAttributes(indexStartBool, boolAttrCount, pBoolKeys, pBoolVals, aBuilders[i]);
 		pcu::unpackAttributes(indexStartDouble, doubleAttrCount, pDoubleKeys, pDoubleVals, aBuilders[i]);
-		pcu::unpackAttributes(indexStartString, stringAttrCount, pStringKeys, pStringVals,
-		                      aBuilders[i]);
-		//TODO: Add array unpacking
+		pcu::unpackStringAttributes(indexStartString, stringAttrCount, pStringKeys, pStringVals,
+		                      aBuilders[i], false);
+		pcu::unpackArrayAttributes<bool>(indexStartBoolArray, boolAttrArrayCount, pBoolArrayKeys, pBoolArrayVals,
+		                           aBuilders[i]);
+		pcu::unpackArrayAttributes<double>(indexStartDoubleArray, doubleAttrArrayCount, pDoubleArrayKeys, pDoubleArrayVals, aBuilders[i]);
+		pcu::unpackStringAttributes(indexStartStringArray, stringAttrArrayCount, pStringArrayKeys, pStringArrayVals,
+		                            aBuilders[i], true);
 
 		indexStartBool += boolAttrCount;
 		indexStartDouble += doubleAttrCount;

--- a/PumaRhino/PumaGrasshopperAPI.cpp
+++ b/PumaRhino/PumaGrasshopperAPI.cpp
@@ -117,12 +117,15 @@ RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
 		int indexStartDoubleArray = *pDoubleArrayStarts->At(i);
 		int indexStartStringArray = *pStringArrayStarts->At(i);
 
-		int boolAttrCount = (i < boolCount - 1 ? *pBoolStarts->At(i + 1) : boolCount) - indexStartBool;
-		int doubleAttrCount = (i < doubleCount - 1 ? *pDoubleStarts->At(i + 1): doubleCount) - indexStartDouble;
-		int stringAttrCount = (i < stringCount - 1 ? *pStringStarts->At(i + 1): stringCount) - indexStartString;
-		int boolAttrArrayCount = (i < boolArrayCount - 1 ? *pBoolArrayStarts->At(i + 1): boolArrayCount) - indexStartBoolArray;
-		int doubleAttrArrayCount = (i < doubleArrayCount - 1 ? *pDoubleArrayStarts->At(i + 1): doubleArrayCount) - indexStartDoubleArray;
-		int stringAttrArrayCount = (i < stringArrayCount - 1 ? *pStringArrayStarts->At(i + 1): stringArrayCount) - indexStartStringArray;
+		int boolAttrCount = (i < shapeCount - 1 ? *pBoolStarts->At(i + 1) : boolCount) - indexStartBool;
+		int doubleAttrCount = (i < shapeCount - 1 ? *pDoubleStarts->At(i + 1): doubleCount) - indexStartDouble;
+		int stringAttrCount = (i < shapeCount - 1 ? *pStringStarts->At(i + 1) : stringCount) - indexStartString;
+		int boolAttrArrayCount =
+		        (i < shapeCount - 1 ? *pBoolArrayStarts->At(i + 1) : boolArrayCount) - indexStartBoolArray;
+		int doubleAttrArrayCount =
+		        (i < shapeCount - 1 ? *pDoubleArrayStarts->At(i + 1) : doubleArrayCount) - indexStartDoubleArray;
+		int stringAttrArrayCount =
+		        (i < shapeCount - 1 ? *pStringArrayStarts->At(i + 1) : stringArrayCount) - indexStartStringArray;
 
 		pcu::unpackBoolAttributes(indexStartBool, boolAttrCount, pBoolKeys, pBoolVals, aBuilders[i]);
 		pcu::unpackDoubleAttributes(indexStartDouble, doubleAttrCount, pDoubleKeys, pDoubleVals, aBuilders[i]);
@@ -250,6 +253,7 @@ RHINOPRT_API int GetRuleAttributesCount() {
 
 RHINOPRT_API bool GetRuleAttribute(int attrIdx, ON_wString* pRule, ON_wString* pName, ON_wString* pNickname,
                                    prt::AnnotationArgumentType* type, ON_wString* pGroup) {
+
 	const RuleAttributes& ruleAttributes = RhinoPRT::get().GetRuleAttributes();
 
 	if (attrIdx >= ruleAttributes.size())
@@ -265,6 +269,25 @@ RHINOPRT_API bool GetRuleAttribute(int attrIdx, ON_wString* pRule, ON_wString* p
 		*pGroup += ON_wString(ruleAttr->groups.front().c_str());
 
 	return true;
+}
+
+RHINOPRT_API int GetRuleAttributes(const wchar_t* rpk_path, ON_ClassArray<ON_wString>* pAttributesBuffer, ON_SimpleArray<int>* pAttributesTypes) {
+
+	RuleAttributes ruleAttributes = RhinoPRT::get().GetRuleAttributes(rpk_path);
+
+	for (const RuleAttributeUPtr& attribute : ruleAttributes) {
+		pAttributesBuffer->Append(ON_wString(attribute->mRuleFile.c_str()));
+		pAttributesBuffer->Append(ON_wString(attribute->mFullName.c_str()));
+		pAttributesBuffer->Append(ON_wString(attribute->mNickname.c_str()));
+		if (attribute->groups.size() > 0)
+			pAttributesBuffer->Append(ON_wString(attribute->groups.front().c_str()));
+		else
+			pAttributesBuffer->Append(ON_wString(L""));
+
+		pAttributesTypes->Append(attribute->mType);
+	}
+
+	return static_cast<int>(ruleAttributes.size());
 }
 
 RHINOPRT_API void GetCGAPrintOutput(int initialShapeIndex, ON_ClassArray<ON_wString>* pPrintOutput) {

--- a/PumaRhino/RhinoPRT.cpp
+++ b/PumaRhino/RhinoPRT.cpp
@@ -49,20 +49,6 @@ bool RhinoPRTAPI::IsPRTInitialized() {
 	return !!PRTContext::get() && PRTContext::get()->isAlive();
 }
 
-int RhinoPRTAPI::GetRuleAttributeCount() {
-	if (!mModelGenerator)
-		mModelGenerator = std::unique_ptr<ModelGenerator>(new ModelGenerator());
-
-	return static_cast<int>(mModelGenerator->getRuleAttributes().size());
-}
-
-const RuleAttributes& RhinoPRTAPI::GetRuleAttributes() {
-	if (!mModelGenerator)
-		mModelGenerator = std::unique_ptr<ModelGenerator>(new ModelGenerator());
-
-	return mModelGenerator->getRuleAttributes();
-}
-
 const RuleAttributes RhinoPRTAPI::GetRuleAttributes(const std::wstring& rulePkg) {
 	if (!mModelGenerator)
 		mModelGenerator = std::unique_ptr<ModelGenerator>(new ModelGenerator());

--- a/PumaRhino/RhinoPRT.cpp
+++ b/PumaRhino/RhinoPRT.cpp
@@ -50,11 +50,23 @@ bool RhinoPRTAPI::IsPRTInitialized() {
 }
 
 int RhinoPRTAPI::GetRuleAttributeCount() {
+	if (!mModelGenerator)
+		mModelGenerator = std::unique_ptr<ModelGenerator>(new ModelGenerator());
+
 	return static_cast<int>(mModelGenerator->getRuleAttributes().size());
 }
 
-const RuleAttributes& RhinoPRTAPI::GetRuleAttributes() const {
+const RuleAttributes& RhinoPRTAPI::GetRuleAttributes() {
+	if (!mModelGenerator)
+		mModelGenerator = std::unique_ptr<ModelGenerator>(new ModelGenerator());
+
 	return mModelGenerator->getRuleAttributes();
+}
+
+const RuleAttributes RhinoPRTAPI::GetRuleAttributes(const std::wstring& rulePkg) {
+	if (!mModelGenerator)
+		mModelGenerator = std::unique_ptr<ModelGenerator>(new ModelGenerator());
+	return mModelGenerator->getRuleAttributes(rulePkg);
 }
 
 std::vector<GeneratedModelPtr> RhinoPRTAPI::GenerateGeometry(const std::wstring& rpk_path,

--- a/PumaRhino/RhinoPRT.cpp
+++ b/PumaRhino/RhinoPRT.cpp
@@ -57,22 +57,6 @@ const RuleAttributes& RhinoPRTAPI::GetRuleAttributes() const {
 	return mModelGenerator->getRuleAttributes();
 }
 
-void RhinoPRTAPI::SetRPKPath(const std::wstring& rpkPath) {
-	// initialize the resolve map and rule infos here. Create the vector of rule attributes.
-	if (!mModelGenerator)
-		mModelGenerator = std::unique_ptr<ModelGenerator>(new ModelGenerator());
-
-	// This also creates the resolve map
-	mModelGenerator->updateRuleFiles(rpkPath); // might throw !
-}
-
-const std::wstring RhinoPRTAPI::GetRPKPath() const {
-	if (!mModelGenerator)
-		return {};
-
-	return mModelGenerator->getPackagePath();
-}
-
 void RhinoPRTAPI::SetInitialShapes(const std::vector<RawInitialShape>& shapes) {
 
 	// get the shape attributes data from ModelGenerator
@@ -106,7 +90,7 @@ std::vector<GeneratedModelPtr> RhinoPRTAPI::GenerateGeometry(const std::wstring&
 	pcu::ShapeAttributes attribute = mModelGenerator->getShapeAttributes(rpk_path);
 	std::vector<pcu::ShapeAttributes> attributes(rawInitialShapes.size(), attribute);
 	
-	std::vector<GeneratedModelPtr> generatedModels = mModelGenerator->generateModel(rawInitialShapes, attributes, aBuilders);
+	std::vector<GeneratedModelPtr> generatedModels = mModelGenerator->generateModel(rpk_path, rawInitialShapes, attributes, aBuilders);
 	assert(generatedModels.size() == rawInitialShapes.size());
 	return generatedModels;
 }

--- a/PumaRhino/RhinoPRT.cpp
+++ b/PumaRhino/RhinoPRT.cpp
@@ -57,89 +57,18 @@ const RuleAttributes& RhinoPRTAPI::GetRuleAttributes() const {
 	return mModelGenerator->getRuleAttributes();
 }
 
-void RhinoPRTAPI::SetInitialShapes(const std::vector<RawInitialShape>& shapes) {
-
-	// get the shape attributes data from ModelGenerator
-	std::wstring rulef = mModelGenerator->getRuleFile();
-	std::wstring ruleN = mModelGenerator->getStartingRule();
-	std::wstring shapeN = mModelGenerator->getDefaultShapeName();
-
-	mShapes.reserve(shapes.size());
-	mAttributes.reserve(shapes.size());
-
-	mShapes.insert(mShapes.end(), shapes.begin(), shapes.end());
-	//mAttributes.resize(mShapes.size(), pcu::ShapeAttributes(rulef, ruleN, shapeN));
-
-	// compute the default values of rule attributes for each initial shape
-	// mModelGenerator->evalDefaultAttributes(mShapes, mAttributes);
-
-}
-
-void RhinoPRTAPI::ClearInitialShapes() {
-	mShapes.clear();
-	mGeneratedModels.clear();
-	mAttributes.clear();
-	mGroupedReports.clear();
-	mAttrBuilders.clear();
-}
-
 std::vector<GeneratedModelPtr> RhinoPRTAPI::GenerateGeometry(const std::wstring& rpk_path,
                                                              std::vector<RawInitialShape>& rawInitialShapes,
                                                              pcu::AttributeMapBuilderVector& aBuilders) {
+	if (!mModelGenerator)
+		mModelGenerator = std::unique_ptr<ModelGenerator>(new ModelGenerator());
+
 	//Build ShapeAttributes
 	pcu::ShapeAttributes attribute = mModelGenerator->getShapeAttributes(rpk_path);
-	std::vector<pcu::ShapeAttributes> attributes(rawInitialShapes.size(), attribute);
 	
-	std::vector<GeneratedModelPtr> generatedModels = mModelGenerator->generateModel(rpk_path, rawInitialShapes, attributes, aBuilders);
+	std::vector<GeneratedModelPtr> generatedModels = mModelGenerator->generateModel(rpk_path, rawInitialShapes, attribute, aBuilders);
 	assert(generatedModels.size() == rawInitialShapes.size());
 	return generatedModels;
-}
-
-const std::vector<GeneratedModelPtr>& RhinoPRTAPI::getGenModels() const {
-	return mGeneratedModels;
-}
-
-void RhinoPRTAPI::setRuleAttributeValue(const int initialShapeIndex, const std::wstring& name, double value,
-                                        size_t /*count*/) {
-	mAttrBuilders[initialShapeIndex]->setFloat(name.c_str(), value);
-}
-
-void RhinoPRTAPI::setRuleAttributeValue(const int initialShapeIndex, const std::wstring& name, int value,
-                                        size_t /*count*/) {
-	mAttrBuilders[initialShapeIndex]->setInt(name.c_str(), value);
-}
-
-void RhinoPRTAPI::setRuleAttributeValue(const int initialShapeIndex, const std::wstring& name, bool value,
-                                        size_t /*count*/) {
-	mAttrBuilders[initialShapeIndex]->setBool(name.c_str(), value);
-}
-
-void RhinoPRTAPI::setRuleAttributeValue(const int initialShapeIndex, const std::wstring& name, std::wstring& value,
-                                        size_t /*count*/) {
-	mAttrBuilders[initialShapeIndex]->setString(name.c_str(), value.c_str());
-}
-
-void RhinoPRTAPI::setRuleAttributeValue(const int initialShapeIndex, const std::wstring& name, const double* value,
-                                        const size_t count) {
-	mAttrBuilders[initialShapeIndex]->setFloatArray(name.c_str(), value, count);
-}
-
-void RhinoPRTAPI::setRuleAttributeValue(const int initialShapeIndex, const std::wstring& name, bool* value,
-                                        const size_t count) {
-	mAttrBuilders[initialShapeIndex]->setBoolArray(name.c_str(), value, count);
-}
-
-void RhinoPRTAPI::setRuleAttributeValue(const int initialShapeIndex, const std::wstring& name,
-                                        std::vector<const wchar_t*> value, const size_t /*count*/) {
-	mAttrBuilders[initialShapeIndex]->setStringArray(name.c_str(), value.data(), value.size());
-}
-
-Reporting::ReportsVector RhinoPRTAPI::getReportsOfModel(int initialShapeIndex) {
-	if ((mGeneratedModels.size() <= initialShapeIndex) || !mGeneratedModels[initialShapeIndex])
-		return Reporting::EMPTY_REPORTS;
-
-	const auto& reports = mGeneratedModels[initialShapeIndex]->getReports();
-	return Reporting::ToReportsVector(reports);
 }
 
 void RhinoPRTAPI::setMaterialGeneration(bool emitMaterial) {

--- a/PumaRhino/RhinoPRT.cpp
+++ b/PumaRhino/RhinoPRT.cpp
@@ -71,7 +71,7 @@ void RhinoPRTAPI::SetInitialShapes(const std::vector<RawInitialShape>& shapes) {
 	//mAttributes.resize(mShapes.size(), pcu::ShapeAttributes(rulef, ruleN, shapeN));
 
 	// compute the default values of rule attributes for each initial shape
-	mModelGenerator->evalDefaultAttributes(mShapes, mAttributes);
+	// mModelGenerator->evalDefaultAttributes(mShapes, mAttributes);
 
 }
 
@@ -84,7 +84,7 @@ void RhinoPRTAPI::ClearInitialShapes() {
 }
 
 std::vector<GeneratedModelPtr> RhinoPRTAPI::GenerateGeometry(const std::wstring& rpk_path,
-                                                             std::vector<RawInitialShape> rawInitialShapes,
+                                                             std::vector<RawInitialShape>& rawInitialShapes,
                                                              pcu::AttributeMapBuilderVector& aBuilders) {
 	//Build ShapeAttributes
 	pcu::ShapeAttributes attribute = mModelGenerator->getShapeAttributes(rpk_path);

--- a/PumaRhino/RhinoPRT.cpp
+++ b/PumaRhino/RhinoPRT.cpp
@@ -55,6 +55,15 @@ const RuleAttributes RhinoPRTAPI::GetRuleAttributes(const std::wstring& rulePkg)
 	return mModelGenerator->getRuleAttributes(rulePkg);
 }
 
+const pcu::AttributeMapPtrVector RhinoPRTAPI::getDefaultAttributes(const std::wstring& rpk_path, 
+																   std::vector<RawInitialShape>& rawInitialShapes) {
+	if (!mModelGenerator)
+		mModelGenerator = std::unique_ptr<ModelGenerator>(new ModelGenerator());
+
+	pcu::ShapeAttributes attributes = mModelGenerator->getShapeAttributes(rpk_path);
+	return mModelGenerator->evalDefaultAttributes(rpk_path, rawInitialShapes, attributes);
+}
+
 std::vector<GeneratedModelPtr> RhinoPRTAPI::GenerateGeometry(const std::wstring& rpk_path,
                                                              std::vector<RawInitialShape>& rawInitialShapes,
                                                              pcu::AttributeMapBuilderVector& aBuilders) {
@@ -62,40 +71,14 @@ std::vector<GeneratedModelPtr> RhinoPRTAPI::GenerateGeometry(const std::wstring&
 		mModelGenerator = std::unique_ptr<ModelGenerator>(new ModelGenerator());
 
 	//Build ShapeAttributes
-	pcu::ShapeAttributes attribute = mModelGenerator->getShapeAttributes(rpk_path);
+	pcu::ShapeAttributes attributes = mModelGenerator->getShapeAttributes(rpk_path);
 	
-	std::vector<GeneratedModelPtr> generatedModels = mModelGenerator->generateModel(rpk_path, rawInitialShapes, attribute, aBuilders);
+	std::vector<GeneratedModelPtr> generatedModels = mModelGenerator->generateModel(rpk_path, rawInitialShapes, attributes, aBuilders);
 	assert(generatedModels.size() == rawInitialShapes.size());
 	return generatedModels;
 }
 
 void RhinoPRTAPI::setMaterialGeneration(bool emitMaterial) {
 	mModelGenerator->updateEncoderOptions(emitMaterial);
-}
-
-bool RhinoPRTAPI::getDefaultValuesBoolean(const std::wstring key, ON_SimpleArray<int>* pValues) {
-	return mModelGenerator->getDefaultValuesBoolean(key, pValues);
-}
-
-bool RhinoPRTAPI::getDefaultValuesNumber(const std::wstring key, ON_SimpleArray<double>* pValues) {
-	return mModelGenerator->getDefaultValuesNumber(key, pValues);
-}
-
-bool RhinoPRTAPI::getDefaultValuesText(const std::wstring key, ON_ClassArray<ON_wString>* pTexts) {
-	return mModelGenerator->getDefaultValuesText(key, pTexts);
-}
-
-bool RhinoPRTAPI::getDefaultValuesBooleanArray(const std::wstring key, ON_SimpleArray<int>* pValues, ON_SimpleArray<int>* pSizes) {
-	return mModelGenerator->getDefaultValuesBooleanArray(key, pValues, pSizes);
-}
-
-bool RhinoPRTAPI::getDefaultValuesNumberArray(const std::wstring key, ON_SimpleArray<double>* pValues,
-                                              ON_SimpleArray<int>* pSizes) {
-	return mModelGenerator->getDefaultValuesNumberArray(key, pValues, pSizes);
-}
-
-bool RhinoPRTAPI::getDefaultValuesTextArray(const std::wstring key, ON_ClassArray<ON_wString>* pTexts,
-                                            ON_SimpleArray<int>* pSizes) {
-	return mModelGenerator->getDefaultValuesTextArray(key, pTexts, pSizes);
 }
 } // namespace RhinoPRT

--- a/PumaRhino/RhinoPRT.cpp
+++ b/PumaRhino/RhinoPRT.cpp
@@ -84,16 +84,11 @@ void RhinoPRTAPI::SetInitialShapes(const std::vector<RawInitialShape>& shapes) {
 	mAttributes.reserve(shapes.size());
 
 	mShapes.insert(mShapes.end(), shapes.begin(), shapes.end());
-	mAttributes.resize(mShapes.size(), pcu::ShapeAttributes(rulef, ruleN, shapeN));
+	//mAttributes.resize(mShapes.size(), pcu::ShapeAttributes(rulef, ruleN, shapeN));
 
 	// compute the default values of rule attributes for each initial shape
 	mModelGenerator->evalDefaultAttributes(mShapes, mAttributes);
 
-	// Initialise the attribute map builders for each initial shape.
-	mAttrBuilders.resize(shapes.size());
-	for (auto& it : mAttrBuilders) {
-		it.reset(prt::AttributeMapBuilder::create());
-	}
 }
 
 void RhinoPRTAPI::ClearInitialShapes() {
@@ -104,10 +99,16 @@ void RhinoPRTAPI::ClearInitialShapes() {
 	mAttrBuilders.clear();
 }
 
-size_t RhinoPRTAPI::GenerateGeometry() {
-	mGeneratedModels = mModelGenerator->generateModel(mShapes, mAttributes, mAttrBuilders);
-	assert(mGeneratedModels.size() == mShapes.size());
-	return mShapes.size();
+std::vector<GeneratedModelPtr> RhinoPRTAPI::GenerateGeometry(const std::wstring& rpk_path,
+                                                             std::vector<RawInitialShape> rawInitialShapes,
+                                                             pcu::AttributeMapBuilderVector& aBuilders) {
+	//Build ShapeAttributes
+	pcu::ShapeAttributes attribute = mModelGenerator->getShapeAttributes(rpk_path);
+	std::vector<pcu::ShapeAttributes> attributes(rawInitialShapes.size(), attribute);
+	
+	std::vector<GeneratedModelPtr> generatedModels = mModelGenerator->generateModel(rawInitialShapes, attributes, aBuilders);
+	assert(generatedModels.size() == rawInitialShapes.size());
+	return generatedModels;
 }
 
 const std::vector<GeneratedModelPtr>& RhinoPRTAPI::getGenModels() const {

--- a/PumaRhino/RhinoPRT.h
+++ b/PumaRhino/RhinoPRT.h
@@ -55,7 +55,9 @@ public:
 	void SetInitialShapes(const std::vector<RawInitialShape>& shapes);
 	void ClearInitialShapes();
 
-	size_t GenerateGeometry();
+	std::vector<GeneratedModelPtr> GenerateGeometry(const std::wstring& rpk_path,
+	                                                       std::vector<RawInitialShape> rawInitialShapes,
+	                                                       pcu::AttributeMapBuilderVector& aBuilders);
 
 	void setRuleAttributeValue(const int initialShapeIndex, const std::wstring& rule, double value, size_t /*count*/);
 	void setRuleAttributeValue(const int initialShapeIndex, const std::wstring& rule, int value, size_t /*count*/);

--- a/PumaRhino/RhinoPRT.h
+++ b/PumaRhino/RhinoPRT.h
@@ -46,9 +46,6 @@ public:
 	void ShutdownRhinoPRT();
 	bool IsPRTInitialized();
 
-	void SetRPKPath(const std::wstring& rpk_path); // might throw!
-	const std::wstring GetRPKPath() const; 
-
 	int GetRuleAttributeCount();
 	const RuleAttributes& GetRuleAttributes() const;
 
@@ -56,8 +53,8 @@ public:
 	void ClearInitialShapes();
 
 	std::vector<GeneratedModelPtr> GenerateGeometry(const std::wstring& rpk_path,
-	                                                       std::vector<RawInitialShape> rawInitialShapes,
-	                                                       pcu::AttributeMapBuilderVector& aBuilders);
+	                                                std::vector<RawInitialShape>& rawInitialShapes,
+	                                                pcu::AttributeMapBuilderVector& aBuilders);
 
 	void setRuleAttributeValue(const int initialShapeIndex, const std::wstring& rule, double value, size_t /*count*/);
 	void setRuleAttributeValue(const int initialShapeIndex, const std::wstring& rule, int value, size_t /*count*/);

--- a/PumaRhino/RhinoPRT.h
+++ b/PumaRhino/RhinoPRT.h
@@ -47,7 +47,8 @@ public:
 	bool IsPRTInitialized();
 
 	int GetRuleAttributeCount();
-	const RuleAttributes& GetRuleAttributes() const;
+	const RuleAttributes& GetRuleAttributes();
+	const RuleAttributes GetRuleAttributes(const std::wstring& rulePkg);
 
 	std::vector<GeneratedModelPtr> GenerateGeometry(const std::wstring& rpk_path,
 	                                                std::vector<RawInitialShape>& rawInitialShapes,

--- a/PumaRhino/RhinoPRT.h
+++ b/PumaRhino/RhinoPRT.h
@@ -46,22 +46,16 @@ public:
 	void ShutdownRhinoPRT();
 	bool IsPRTInitialized();
 
-	int GetRuleAttributeCount();
-	const RuleAttributes& GetRuleAttributes();
 	const RuleAttributes GetRuleAttributes(const std::wstring& rulePkg);
+
+	const pcu::AttributeMapPtrVector getDefaultAttributes(const std::wstring& rpk_path,
+	                                                  std::vector<RawInitialShape>& rawInitialShapes);
 
 	std::vector<GeneratedModelPtr> GenerateGeometry(const std::wstring& rpk_path,
 	                                                std::vector<RawInitialShape>& rawInitialShapes,
 	                                                pcu::AttributeMapBuilderVector& aBuilders);
 
 	void setMaterialGeneration(bool emitMaterial);
-
-	bool getDefaultValuesBoolean(const std::wstring key, ON_SimpleArray<int>* pValues);
-	bool getDefaultValuesNumber(const std::wstring key, ON_SimpleArray<double>* pValues);
-	bool getDefaultValuesText(const std::wstring key, ON_ClassArray<ON_wString>* pTexts);
-	bool getDefaultValuesBooleanArray(const std::wstring key, ON_SimpleArray<int>* pValues, ON_SimpleArray<int>* pSizes);
-	bool getDefaultValuesNumberArray(const std::wstring key, ON_SimpleArray<double>* pValues, ON_SimpleArray<int>* pSizes);
-	bool getDefaultValuesTextArray(const std::wstring key, ON_ClassArray<ON_wString>* pTexts, ON_SimpleArray<int>* pSizes);
 
 private:
 	std::vector<RawInitialShape> mShapes;

--- a/PumaRhino/RhinoPRT.h
+++ b/PumaRhino/RhinoPRT.h
@@ -49,30 +49,9 @@ public:
 	int GetRuleAttributeCount();
 	const RuleAttributes& GetRuleAttributes() const;
 
-	void SetInitialShapes(const std::vector<RawInitialShape>& shapes);
-	void ClearInitialShapes();
-
 	std::vector<GeneratedModelPtr> GenerateGeometry(const std::wstring& rpk_path,
 	                                                std::vector<RawInitialShape>& rawInitialShapes,
 	                                                pcu::AttributeMapBuilderVector& aBuilders);
-
-	void setRuleAttributeValue(const int initialShapeIndex, const std::wstring& rule, double value, size_t /*count*/);
-	void setRuleAttributeValue(const int initialShapeIndex, const std::wstring& rule, int value, size_t /*count*/);
-	void setRuleAttributeValue(const int initialShapeIndex, const std::wstring& rule, bool value, size_t /*count*/);
-	void setRuleAttributeValue(const int initialShapeIndex, const std::wstring& rule, std::wstring& value,
-	                           size_t /*count*/);
-	void setRuleAttributeValue(const int initialShapeIndex, const std::wstring& rule, const double* value,
-	                           const size_t count);
-	void setRuleAttributeValue(const int initialShapeIndex, const std::wstring& rule, bool* value, const size_t count);
-	void setRuleAttributeValue(const int initialShapeIndex, const std::wstring& rule, std::vector<const wchar_t*> value,
-	                           const size_t /*count*/);
-
-	const Reporting::GroupedReports& getReports() const {
-		return mGroupedReports;
-	}
-	Reporting::ReportsVector getReportsOfModel(int initialShapeIndex);
-
-	const std::vector<GeneratedModelPtr>& getGenModels() const;
 
 	void setMaterialGeneration(bool emitMaterial);
 
@@ -90,9 +69,6 @@ private:
 	pcu::AttributeMapBuilderVector mAttrBuilders;
 
 	std::unique_ptr<ModelGenerator> mModelGenerator;
-	std::vector<GeneratedModelPtr> mGeneratedModels;
-
-	Reporting::GroupedReports mGroupedReports;
 };
 
 // Global PRT handle

--- a/PumaRhino/utils.cpp
+++ b/PumaRhino/utils.cpp
@@ -56,7 +56,7 @@ void checkLastError(const std::string& exceptionPrefix) {
 
 namespace pcu {
 
-ShapeAttributes::ShapeAttributes(pcu::RuleFileInfoPtr ruleFileInfo, const std::wstring rulef, const std::wstring startRl,
+ShapeAttributes::ShapeAttributes(pcu::RuleFileInfoPtr& ruleFileInfo, const std::wstring rulef, const std::wstring startRl,
                                  const std::wstring shapeN, int seed)
     : ruleFileInfo(ruleFileInfo.get()), ruleFile(rulef), startRule(startRl), shapeName(shapeN), seed(seed) {}
 

--- a/PumaRhino/utils.cpp
+++ b/PumaRhino/utils.cpp
@@ -214,6 +214,12 @@ void appendToRhinoString(ON_wString& rhinoString, const std::wstring& appendee) 
 	rhinoString += appendee.c_str();
 }
 
+void appendColor(const ON_Color& color, ON_SimpleArray<int>* pArray){
+	pArray->Append(color.Red());
+	pArray->Append(color.Green());
+	pArray->Append(color.Blue());
+}
+
 std::string percentEncode(const std::string& utf8String) {
 	return callAPI<char, char>(prt::StringUtils::percentEncode, utf8String);
 }

--- a/PumaRhino/utils.cpp
+++ b/PumaRhino/utils.cpp
@@ -56,8 +56,9 @@ void checkLastError(const std::string& exceptionPrefix) {
 
 namespace pcu {
 
-ShapeAttributes::ShapeAttributes(const std::wstring rulef, const std::wstring startRl, const std::wstring shapeN)
-    : ruleFile(rulef), startRule(startRl), shapeName(shapeN) {}
+ShapeAttributes::ShapeAttributes(pcu::RuleFileInfoPtr ruleFileInfo, const std::wstring rulef, const std::wstring startRl,
+                                 const std::wstring shapeN, int seed)
+    : ruleFileInfo(ruleFileInfo.get()), ruleFile(rulef), startRule(startRl), shapeName(shapeN), seed(seed) {}
 
 // location of RhinoPRT shared library
 std::filesystem::path getDllLocation() {

--- a/PumaRhino/utils.cpp
+++ b/PumaRhino/utils.cpp
@@ -374,47 +374,6 @@ const std::wstring toCeArray(const int* values, size_t count) {
  * Interop helpers
  */
 
-template <typename T>
-void fillMapBuilder(const std::wstring& /* key */, T /* value */, AttributeMapBuilderPtr& /* aBuilder */) {
-	throw std::invalid_argument("Received type is not supported");
-}
-
-template <>
-void fillMapBuilder<int>(const std::wstring& key, int value, AttributeMapBuilderPtr& aBuilder) {
-	aBuilder->setBool(key.c_str(), static_cast<bool>(value));
-}
-
-template <>
-void fillMapBuilder<double>(const std::wstring& key, double value, AttributeMapBuilderPtr& aBuilder) {
-	aBuilder->setFloat(key.c_str(), value);
-}
-
-template <typename T>
-void fillArrayMapBuilder(const std::wstring& /* key */, const std::vector<const wchar_t*>& /* values */,
-                         AttributeMapBuilderPtr& /* aBuilder */) {
-	throw std::invalid_argument("Received type is not supported");
-}
-
-template <>
-void fillArrayMapBuilder<bool>(const std::wstring& key, const std::vector<const wchar_t*>& values,
-                               AttributeMapBuilderPtr& aBuilder) {
-	bool* bArray = new bool[values.size()];
-	for (int i = 0; i < values.size(); ++i) {
-		bArray[i] = (bool)(std::wstring(values[i]) == L"true");
-	}
-	aBuilder->setBoolArray(key.c_str(), bArray, values.size());
-}
-
-template <>
-void fillArrayMapBuilder<double>(const std::wstring& key, const std::vector<const wchar_t*>& values,
-                                 AttributeMapBuilderPtr& aBuilder) {
-	double* dArray = new double[values.size()];
-	for (int i = 0; i < values.size(); ++i) {
-		dArray[i] = (double)std::stod(std::wstring(values[i]));
-	}
-	aBuilder->setFloatArray(key.c_str(), dArray, values.size());
-}
-
 void unpackDoubleAttributes(int start, int count, ON_ClassArray<ON_wString>* keys, ON_SimpleArray<double>* values,
                       AttributeMapBuilderPtr& aBuilder) {
 	for (int i = start; i < start + count; ++i) {

--- a/PumaRhino/utils.cpp
+++ b/PumaRhino/utils.cpp
@@ -338,6 +338,38 @@ std::vector<const wchar_t*> fromCeArray(const std::wstring& stringArray) {
 	return pcu::split(stringArray, CE_ARRAY_DELIMITER);
 }
 
+const std::wstring toCeArray(const wchar_t* const* values, size_t count) {
+	std::wstring serializedArray;
+	for (size_t i = 0; i < count; ++i) {
+		serializedArray += std::wstring(values[i]) + CE_ARRAY_DELIMITER;
+	}
+	return serializedArray;
+}
+
+const std::wstring toCeArray(const bool* values, size_t count) {
+	std::wstring serializedArray;
+	for (size_t i = 0; i < count; ++i) {
+		serializedArray += std::wstring(values[i] ? L"true" : L"false") + CE_ARRAY_DELIMITER;
+	}
+	return serializedArray;
+}
+
+const std::wstring toCeArray(const double* values, size_t count) {
+	std::wstring serializedArray;
+	for (size_t i = 0; i < count; ++i) {
+		serializedArray +=  std::to_wstring(values[i]) + CE_ARRAY_DELIMITER;
+	}
+	return serializedArray;
+}
+
+const std::wstring toCeArray(const int* values, size_t count) {
+	std::wstring serializedArray;
+	for (size_t i = 0; i < count; ++i) {
+		serializedArray +=  std::to_wstring(values[i]) + CE_ARRAY_DELIMITER;
+	}
+	return serializedArray;
+}
+
 /**
  * Interop helpers
  */
@@ -434,5 +466,15 @@ void unpackStringAttributes(int start, int count, ON_ClassArray<ON_wString>* key
 		else
 			aBuilder->setString(key.c_str(), values->At(i)->Array());
 	}
+}
+
+void logAttributeTypeError(const std::wstring& key) {
+	LOG_ERR << "Impossible to get default value for rule attribute: " << key
+	        << " The expected type does not correspond to the actual type of this attribute.";
+}
+
+void logAttributeError(const std::wstring& key, prt::Status& status) {
+	LOG_ERR << "Impossible to get default value for rule attribute: " << key
+	        << " with error: " << prt::getStatusDescription(status);
 }
 } // namespace pcu

--- a/PumaRhino/utils.h
+++ b/PumaRhino/utils.h
@@ -144,6 +144,10 @@ std::basic_string<C>& replace_not_in_range(std::basic_string<C>& str, const std:
 std::vector<const wchar_t*> split(const std::wstring& i_str, const std::wstring& i_delim);
 
 std::vector<const wchar_t*> fromCeArray(const std::wstring& stringArray);
+const std::wstring toCeArray(const wchar_t* const* values, size_t count);
+const std::wstring toCeArray(const bool* values, size_t count);
+const std::wstring toCeArray(const double* values, size_t count);
+const std::wstring toCeArray(const int* values, size_t count);
 
 /**
  * Interop helpers
@@ -186,5 +190,9 @@ struct PathRemover {
 };
 
 using ScopedPath = std::unique_ptr<std::filesystem::path, PathRemover>;
+
+void logAttributeTypeError(const std::wstring& key);
+
+void logAttributeError(const std::wstring& key, prt::Status& status);
 
 } // namespace pcu

--- a/PumaRhino/utils.h
+++ b/PumaRhino/utils.h
@@ -83,7 +83,6 @@ using FileOutputCallbacksPtr = std::unique_ptr<prt::FileOutputCallbacks, PRTDest
 using ConsoleLogHandlerPtr = std::unique_ptr<prt::ConsoleLogHandler, PRTDestroyer>;
 using FileLogHandlerPtr = std::unique_ptr<prt::FileLogHandler, PRTDestroyer>;
 using RuleFileInfoPtr = std::unique_ptr<const prt::RuleFileInfo, PRTDestroyer>;
-// using RuleFileInfoSPtr = std::shared_ptr<const prt::RuleFileInfo>;
 using EncoderInfoPtr = std::unique_ptr<const prt::EncoderInfo, PRTDestroyer>;
 using DecoderInfoPtr = std::unique_ptr<const prt::DecoderInfo, PRTDestroyer>;
 using SimpleOutputCallbacksPtr = std::unique_ptr<prt::SimpleOutputCallbacks, PRTDestroyer>;
@@ -99,8 +98,6 @@ struct ShapeAttributes {
 	ShapeAttributes(RuleFileInfoPtr ruleFileInfo, const std::wstring rulef = L"bin/rule.cgb",
 	                const std::wstring startRl = L"Default$Lot", const std::wstring shapeN = L"Lot",
 	                const int seed = 0);
-
-	ShapeAttributes(const pcu::ShapeAttributes& attributes);
 };
 
 AttributeMapPtr createAttributeMapForShape(const ShapeAttributes& attrs, prt::AttributeMapBuilder& bld);

--- a/PumaRhino/utils.h
+++ b/PumaRhino/utils.h
@@ -114,6 +114,7 @@ std::string toUTF8FromUTF16(const std::wstring& utf16String);
 std::string toUTF8FromOSNarrow(const std::string& osString);
 
 void appendToRhinoString(ON_wString& rhinoString, const std::wstring& appendee);
+void appendColor(const ON_Color& color, ON_SimpleArray<int>* pArray);
 
 std::string percentEncode(const std::string& utf8String);
 std::string toFileURI(const std::string& osNarrowPath);
@@ -166,7 +167,7 @@ std::vector<const wchar_t*> fromCeArray(const std::wstring& stringArray) {
  */
 
 template<typename T>
-void fillMapBuilder(const std::wstring& key, T value, AttributeMapBuilderPtr& aBuilder) {
+void fillMapBuilder(const std::wstring& /* key */, T value, AttributeMapBuilderPtr& aBuilder) {
 	throw std::invalid_argument("Received type is not supported");
 }
 
@@ -181,24 +182,24 @@ void fillMapBuilder<double>(const std::wstring& key, double value, AttributeMapB
 }
 
 template<typename T>
-void fillArrayMapBuilder(const std::wstring& key, const std::vector<std::wstring>& values, AttributeMapBuilderPtr& aBuilder) {
+void fillArrayMapBuilder(const std::wstring& key, const std::vector<const wchar_t*>& values, AttributeMapBuilderPtr& aBuilder) {
 	throw std::invalid_argument("Received type is not supported");
 }
 
 template<>
-void fillArrayMapBuilder<bool>(const std::wstring& key, const std::vector<std::wstring>& values, AttributeMapBuilderPtr& aBuilder) {
+void fillArrayMapBuilder<bool>(const std::wstring& key, const std::vector<const wchar_t*>& values, AttributeMapBuilderPtr& aBuilder) {
 	bool* bArray = new bool[values.size()];
 	for (int i = 0; i < values.size(); ++i) {
-		bArray[i] = values[i] == L"true";
+		bArray[i] = (bool)(std::wstring(values[i]) == L"true");
 	}
 	aBuilder->setBoolArray(key.c_str(), bArray, values.size());
 }
 
 template<>
-void fillArrayMapBuilder<double>(const std::wstring& key, const std::vector<std::wstring>& values, AttributeMapBuilderPtr& aBuilder) {
+void fillArrayMapBuilder<double>(const std::wstring& key, const std::vector<const wchar_t*>& values, AttributeMapBuilderPtr& aBuilder) {
 	double* dArray = new double[values.size()];
 	for (int i = 0; i < values.size(); ++i) {
-		dArray[i] = std::stod(values[i]);
+		dArray[i] = (double)std::stod(std::wstring(values[i]));
 	}
 	aBuilder->setFloatArray(key.c_str(), dArray, values.size());
 }
@@ -218,7 +219,7 @@ void unpackArrayAttributes(int start, int count, ON_ClassArray<ON_wString>* keys
 	AttributeMapBuilderPtr& aBuilder) {
 	for (int i = start; i < start + count; ++i) {
 		const std::wstring key(keys->At(i)->Array());
-		auto vArray = fromCeArray(values->At(i)->Array());
+		const auto vArray = fromCeArray(values->At(i)->Array());
 		pcu::fillArrayMapBuilder<T>(key, vArray, aBuilder);
 	}
 }

--- a/PumaRhino/utils.h
+++ b/PumaRhino/utils.h
@@ -154,11 +154,47 @@ const std::wstring toCeArray(const int* values, size_t count);
  */
 
 template<typename T>
-void fillMapBuilder(const std::wstring& /* key */, T /* value */, AttributeMapBuilderPtr& /* aBuilder */);
+void fillMapBuilder(const std::wstring& /* key */, T /* value */, AttributeMapBuilderPtr& /* aBuilder */) {
+	static_assert(std::is_same<T, int>::value || std::is_same<T, double>::value || std::is_same<T, bool>::value,
+	              "Type T must be one of int, double or bool");
+}
 
 template<typename T>
 void fillArrayMapBuilder(const std::wstring& /* key */, const std::vector<const wchar_t*>& /* values */,
-                         AttributeMapBuilderPtr& /* aBuilder */);
+	AttributeMapBuilderPtr& /* aBuilder */) {
+	static_assert(std::is_same<T, int>::value || std::is_same<T, double>::value || std::is_same<T, bool>::value,
+	              "Type T must be one of int, double or bool");
+}
+
+template <>
+inline void fillMapBuilder<int>(const std::wstring& key, int value, AttributeMapBuilderPtr& aBuilder) {
+	aBuilder->setBool(key.c_str(), static_cast<bool>(value));
+}
+
+template <>
+inline void fillMapBuilder<double>(const std::wstring& key, double value, AttributeMapBuilderPtr& aBuilder) {
+	aBuilder->setFloat(key.c_str(), value);
+}
+
+template <>
+inline void fillArrayMapBuilder<bool>(const std::wstring& key, const std::vector<const wchar_t*>& values,
+                               AttributeMapBuilderPtr& aBuilder) {
+	bool* bArray = new bool[values.size()];
+	for (int i = 0; i < values.size(); ++i) {
+		bArray[i] = (bool)(std::wstring(values[i]) == L"true");
+	}
+	aBuilder->setBoolArray(key.c_str(), bArray, values.size());
+}
+
+template <>
+inline void fillArrayMapBuilder<double>(const std::wstring& key, const std::vector<const wchar_t*>& values,
+                                 AttributeMapBuilderPtr& aBuilder) {
+	double* dArray = new double[values.size()];
+	for (int i = 0; i < values.size(); ++i) {
+		dArray[i] = (double)std::stod(std::wstring(values[i]));
+	}
+	aBuilder->setFloatArray(key.c_str(), dArray, values.size());
+}
 
 
 void unpackBoolAttributes(int start, int count, ON_ClassArray<ON_wString>* keys, ON_SimpleArray<int>* values,

--- a/PumaRhino/utils.h
+++ b/PumaRhino/utils.h
@@ -59,19 +59,6 @@ char getDirSeparator();
 template <>
 wchar_t getDirSeparator();
 
-struct ShapeAttributes {
-	std::wstring ruleFile;
-	std::wstring startRule;
-	std::wstring shapeName;
-	pcu::RuleFileInfoPtr ruleFileInfo;
-	int seed;
-
-	ShapeAttributes(pcu::RuleFileInfoPtr ruleFileInfo, const std::wstring rulef = L"bin/rule.cgb",
-	                const std::wstring startRl = L"Default$Lot",
-	                const std::wstring shapeN = L"Lot",
-					const int seed = 0);
-};
-
 /**
  * helpers for prt object management
  */
@@ -96,10 +83,23 @@ using FileOutputCallbacksPtr = std::unique_ptr<prt::FileOutputCallbacks, PRTDest
 using ConsoleLogHandlerPtr = std::unique_ptr<prt::ConsoleLogHandler, PRTDestroyer>;
 using FileLogHandlerPtr = std::unique_ptr<prt::FileLogHandler, PRTDestroyer>;
 using RuleFileInfoPtr = std::unique_ptr<const prt::RuleFileInfo, PRTDestroyer>;
+using RuleFileInfoSPtr = std::unique_ptr<const prt::RuleFileInfo, PRTDestroyer>;
 using EncoderInfoPtr = std::unique_ptr<const prt::EncoderInfo, PRTDestroyer>;
 using DecoderInfoPtr = std::unique_ptr<const prt::DecoderInfo, PRTDestroyer>;
 using SimpleOutputCallbacksPtr = std::unique_ptr<prt::SimpleOutputCallbacks, PRTDestroyer>;
 using RhinoCallbacksPtr = std::unique_ptr<RhinoCallbacks>;
+
+struct ShapeAttributes {
+	std::wstring ruleFile;
+	std::wstring startRule;
+	std::wstring shapeName;
+	RuleFileInfoPtr ruleFileInfo;
+	int seed;
+
+	ShapeAttributes(RuleFileInfoPtr& ruleFileInfo, const std::wstring rulef = L"bin/rule.cgb",
+	                const std::wstring startRl = L"Default$Lot", const std::wstring shapeN = L"Lot",
+	                const int seed = 0);
+};
 
 AttributeMapPtr createAttributeMapForShape(const ShapeAttributes& attrs, prt::AttributeMapBuilder& bld);
 AttributeMapPtr createValidatedOptions(const wchar_t* encID, const prt::AttributeMap* unvalidatedOptions = nullptr);
@@ -208,7 +208,7 @@ void unpackAttributes(int start, int count, ON_ClassArray<ON_wString>* keys, ON_
 	for (int i = start; i < start + count; ++i) {
 		const std::wstring key(keys->At(i)->Array());
 
-		const T value(values->At(i));
+		const T value(*values->At(i));
 		pcu::fillMapBuilder(key, value, aBuilder);
 	}
 }


### PR DESCRIPTION
JIRA: https://zrh-web.esri.com/jira/browse/CE-9592

This PR aims at refactoring the `ModelGenerator` and `RhinoPRTAPI` to make them stateless. This is still a work in progress.

### Implementation

- Removed class variables of `ModelGenerator` and `RhinoPRTAPI` that are used for the generation.
- Removed API functions that were setting rule attribute values to `ModelGenerator`. Instead, attribute values are now encoded into a big map and passed when calling `Generate`.
- Refactored API function `Generate` to take all arguments needed for the generation.
- Refactored API function `Generate` to return meshes, reports and materials in one container object.
- Made the rule attribute extraction stateless by providing a function that extracts rule attributes from the rule.
- Make the default value evaluation stateless as well.

**Remaining work:**
- Add CGA prints and errors to the returned elements of generate.
- Refactor how the flag `doGenerateMaterial` is passed. Add it as an argument of `Generate`.