### PR TITLE
Update PRT version to 2.6.8300

### DIFF
--- a/PumaDependencies/PumaDependencies.vcxproj
+++ b/PumaDependencies/PumaDependencies.vcxproj
@@ -14,7 +14,7 @@
     <ProjectName>PumaDependencies</ProjectName>
   </PropertyGroup>
   <PropertyGroup>
-    <PRTUrl>https://github.com/Esri/cityengine-sdk/releases/download/2.5.7799/esri_ce_sdk-2.5.7799-win10-vc1427-x86_64-rel-opt.zip</PRTUrl>
+    <PRTUrl>https://github.com/Esri/cityengine-sdk/releases/download/2.6.8300/esri_ce_sdk-2.6.8300-win10-vc1427-x86_64-rel-opt.zip</PRTUrl>
     <OutputDirectory>$(SolutionDir)build\</OutputDirectory>
     <DependencyDir>$(SolutionDir)deps\</DependencyDir>
   </PropertyGroup>


### PR DESCRIPTION
JIRA: https://zrh-jira.esri.com/browse/CE-10327

I bumped the version of PRT in `PumaDependencies` to 2.6.8300.

I did a clean build and tested with a few RPKs.