### PR TITLE
Fixing various bugs

### DIFF
--- a/PumaGrasshopper/Annotations.cs
+++ b/PumaGrasshopper/Annotations.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace PumaGrasshopper.Annotations
 {
-    public enum AnnotationArgumentType { AAT_VOID, AAT_BOOL, AAT_FLOAT, AAT_STR, AAT_INT, AAT_UNKNOWN, AAT_BOOL_ARRAY, AAT_FLOAT_ARRAY, AAT_STR_ARRAY };
+    public enum AnnotationArgumentType { AAT_VOID, AAT_BOOL, AAT_FLOAT, AAT_STR, AAT_INT, AAT_UNKNOWN, AAT_BOOL_ARRAY, AAT_FLOAT_ARRAY, AAT_STR_ARRAY, AAT_INT_ARRAY };
     public enum AttributeAnnotation { A_COLOR = 0, A_RANGE, A_ENUM, A_FILE, A_DIR, A_NOANNOT };
     public enum EnumAnnotationType { ENUM_DOUBLE = 0, ENUM_BOOL, ENUM_STRING };
 

--- a/PumaGrasshopper/AttributeParameter.cs
+++ b/PumaGrasshopper/AttributeParameter.cs
@@ -140,24 +140,6 @@ namespace PumaGrasshopper.AttributeParameter
         {
             if (PersistentDataCount > 0) return PersistentData;
 
-            if (mExpectsArray)
-            {
-                //TODO refactor -> get value from local attribute list
-                List<List<bool>> defaultValues = PRTWrapper.GetDefaultValuesBooleanArray(Name);
-                if (defaultValues != null)
-                {
-                    return Utils.FromListToTree(defaultValues);
-                }
-            }
-            else
-            {
-                List<bool> defaultValues = PRTWrapper.GetDefaultValuesBoolean(Name);
-                if (defaultValues != null)
-                {
-                    return Utils.FromListToTree(defaultValues);
-                }
-            }
-
             return new GH_Structure<GH_Boolean>();
         }
 
@@ -207,25 +189,6 @@ namespace PumaGrasshopper.AttributeParameter
         private GH_Structure<GH_Number> GetData()
         {
             if (PersistentDataCount > 0) return PersistentData;
-
-            if (mExpectsArray)
-            {
-                //TODO refactor -> get value from local attribute list
-                List<List<double>> defaultValues = PRTWrapper.GetDefaultValuesNumberArray(Name);
-                if (defaultValues != null)
-                {
-                    return Utils.FromListToTree(defaultValues);
-                }
-            }
-            else
-            {
-                //TODO refactor -> get value from local attribute list
-                List<double> defaultValues = PRTWrapper.GetDefaultValuesNumber(Name);
-                if(defaultValues != null)
-                {
-                    return Utils.FromListToTree(defaultValues);
-                }
-            }
 
             return new GH_Structure<GH_Number>();
         }
@@ -284,25 +247,6 @@ namespace PumaGrasshopper.AttributeParameter
         private GH_Structure<GH_String> GetData()
         {
             if (PersistentDataCount > 0) return PersistentData;
-
-            if (mExpectsArray)
-            {
-                //TODO refactor -> get value from local attribute list
-                List<List<string>> defaultValues = PRTWrapper.GetDefaultValuesTextArray(Name);
-                if (defaultValues != null)
-                {
-                    return Utils.FromListToTree(defaultValues);
-                }
-            }
-            else
-            {
-                //TODO refactor -> get value from local attribute list
-                List<string> defaultValues = PRTWrapper.GetDefaultValuesText(Name);
-                if (defaultValues != null)
-                {
-                    return Utils.FromListToTree(defaultValues);
-                }
-            }
 
             return new GH_Structure<GH_String>();
         }
@@ -370,13 +314,6 @@ namespace PumaGrasshopper.AttributeParameter
         private GH_Structure<GH_Colour> GetData()
         {
             if (PersistentDataCount > 0) return PersistentData;
-
-            //TODO refactor -> get value from local attribute list
-            List<string> defaultValues = PRTWrapper.GetDefaultValuesText(Name);
-            if (defaultValues != null)
-            {
-                return Utils.HexListToColorTree(defaultValues);
-            }
             
             return new GH_Structure<GH_Colour>();
         }

--- a/PumaGrasshopper/AttributesValuesMap.cs
+++ b/PumaGrasshopper/AttributesValuesMap.cs
@@ -11,26 +11,36 @@ namespace PumaGrasshopper
     public class AttributesValuesMap
     {
         private Dictionary<string, bool> mDefaultBooleans;
+        private Dictionary<string, int> mDefaultIntegers;
         private Dictionary<string, string> mDefaultStrings;
         private Dictionary<string, double> mDefaultDoubles;
         private Dictionary<string, bool[]> mDefaultBoolArrays;
+        private Dictionary<string, int[]> mDefaultIntegerArrays;
         private Dictionary<string, string[]> mDefaultStringArrays;
         private Dictionary<string, double[]> mDefaultDoubleArrays;
 
-        public AttributesValuesMap(string[] boolKeys, bool[] boolValues, string[] stringKeys, string[] stringValues,
-                                string[] doubleKeys, double[] doubleValues, string[] boolArrayKeys, string[] boolArrayValues,
+        public AttributesValuesMap(string[] boolKeys, bool[] boolValues, string[] integerKeys, int[] integerValues,
+                                string[] stringKeys, string[] stringValues, string[] doubleKeys, double[] doubleValues,
+                                string[] boolArrayKeys, string[] boolArrayValues, string[] integerArrayKeys, string[] integerArrayValues,
                                 string[] stringArrayKeys, string[] stringArrayValues, string[] doubleArrayKeys, string[] doubleArrayValues)
         {
             mDefaultBooleans = new Dictionary<string, bool>();
+            mDefaultIntegers = new Dictionary<string, int>();
             mDefaultStrings = new Dictionary<string, string>();
             mDefaultDoubles = new Dictionary<string, double>();
             mDefaultBoolArrays = new Dictionary<string, bool[]>();
+            mDefaultIntegerArrays = new Dictionary<string, int[]>();
             mDefaultStringArrays = new Dictionary<string, string[]>();
             mDefaultDoubleArrays = new Dictionary<string, double[]>();
 
             for(int i = 0; i < boolKeys.Length; ++i)
             {
                 mDefaultBooleans.Add(boolKeys[i], boolValues[i]);
+            }
+
+            for(int i = 0; i < integerKeys.Length; ++i)
+            {
+                mDefaultIntegers.Add(integerKeys[i], integerValues[i]);
             }
 
             for(int i = 0; i < stringKeys.Length; ++i)
@@ -46,6 +56,11 @@ namespace PumaGrasshopper
             for(int i = 0; i < boolArrayKeys.Length; ++i)
             {
                 mDefaultBoolArrays.Add(boolArrayKeys[i], Utils.BoolFromCeArray(boolArrayValues[i]));
+            }
+
+            for(int i = 0; i < integerArrayKeys.Length; ++i)
+            {
+                mDefaultIntegerArrays.Add(integerArrayKeys[i], Utils.IntegerFromCeArray(integerArrayValues[i]));
             }
 
             for(int i = 0; i < stringArrayKeys.Length; ++i)
@@ -64,6 +79,11 @@ namespace PumaGrasshopper
             return mDefaultBooleans.TryGetValue(key, out value);
         }
 
+        public bool GetInteger(string key, out int value)
+        {
+            return mDefaultIntegers.TryGetValue(key, out value);
+        }
+
         public bool GetString(string key, out string value)
         {
             return mDefaultStrings.TryGetValue(key, out value);
@@ -79,6 +99,11 @@ namespace PumaGrasshopper
             return mDefaultBoolArrays.TryGetValue(key, out values);
         }
 
+        public bool GetIntegerArray(string key, out int[] values)
+        {
+            return mDefaultIntegerArrays.TryGetValue(key, out values);
+        }
+
         public bool GetStringArray(string key, out string[] values)
         {
             return mDefaultStringArrays.TryGetValue(key, out values);
@@ -90,15 +115,20 @@ namespace PumaGrasshopper
         }
 
         public static AttributesValuesMap[] FromInteropWrappers(int shapeCount, ref InteropWrapperBoolean boolWrapper,
+                                                           ref InteropWrapperInteger integerWrapper,
                                                            ref InteropWrapperString stringWrapper,
                                                            ref InteropWrapperDouble doubleWrapper,
                                                            ref InteropWrapperString boolArrayWrapper,
+                                                           ref InteropWrapperString integerArrayWrapper,
                                                            ref InteropWrapperString stringArrayWrapper,
                                                            ref InteropWrapperString doubleArrayWrapper)
         {
             int[] boolStarts = boolWrapper.StartsToArray();
             string[] boolKeys = boolWrapper.KeysToArray();
             bool[] boolValues = boolWrapper.ValuesToArray();
+            int[] integerStarts = integerWrapper.StartsToArray();
+            string[] integerKeys = integerWrapper.KeysToArray();
+            int[] integerValues = integerWrapper.ValuesToArray();
             int[] stringStarts = stringWrapper.StartsToArray();
             string[] stringKeys = stringWrapper.KeysToArray();
             string[] stringValues = stringWrapper.ValuesToArray();
@@ -108,6 +138,9 @@ namespace PumaGrasshopper
             int[] boolArrayStarts = boolArrayWrapper.StartsToArray();
             string[] boolArrayKeys = boolArrayWrapper.KeysToArray();
             string[] boolArrayValues = boolArrayWrapper.ValuesToArray();
+            int[] integerArrayStarts = integerArrayWrapper.StartsToArray();
+            string[] integerArrayKeys = integerArrayWrapper.KeysToArray();
+            string[] integerArrayValues = integerArrayWrapper.ValuesToArray();
             int[] stringArrayStarts = stringArrayWrapper.StartsToArray();
             string[] stringArrayKeys = stringArrayWrapper.KeysToArray();
             string[] stringArrayValues = stringArrayWrapper.ValuesToArray();
@@ -119,26 +152,34 @@ namespace PumaGrasshopper
             for (int i = 0; i < shapeCount; ++i)
             {
                 int boolStart = boolStarts[i];
+                int integerStart = integerStarts[i];
                 int stringStart = stringStarts[i];
                 int doubleStart = doubleStarts[i];
                 int boolArrayStart = boolArrayStarts[i];
+                int integerArrayStart = integerArrayStarts[i];
                 int stringArrayStart = stringArrayStarts[i];
                 int doubleArrayStart = doubleArrayStarts[i];
                 int boolCount = GetIntervalCount(i, shapeCount, boolStarts, boolKeys.Length);
+                int integerCount = GetIntervalCount(i, shapeCount, integerStarts, integerKeys.Length);
                 int stringCount = GetIntervalCount(i, shapeCount, stringStarts, stringKeys.Length);
                 int doubleCount = GetIntervalCount(i, shapeCount, doubleStarts, doubleKeys.Length);
                 int boolArrayCount = GetIntervalCount(i, shapeCount, boolArrayStarts, boolArrayKeys.Length);
+                int integerArrayCount = GetIntervalCount(i, shapeCount, integerArrayStarts, integerArrayKeys.Length);
                 int stringArrayCount = GetIntervalCount(i, shapeCount, stringArrayStarts, stringArrayKeys.Length);
                 int doubleArrayCount = GetIntervalCount(i, shapeCount, doubleArrayStarts, doubleArrayKeys.Length);
 
                 defaultValues[i] = new AttributesValuesMap(boolKeys.Skip(boolStart).Take(boolCount).ToArray(),
                     boolValues.Skip(boolStart).Take(boolCount).ToArray(),
+                    integerKeys.Skip(integerStart).Take(integerCount).ToArray(),
+                    integerValues.Skip(integerStart).Take(integerCount).ToArray(),
                     stringKeys.Skip(stringStart).Take(stringCount).ToArray(), 
                     stringValues.Skip(stringStart).Take(stringCount).ToArray(),
                     doubleKeys.Skip(doubleStart).Take(doubleCount).ToArray(),
                     doubleValues.Skip(doubleStart).Take(doubleCount).ToArray(),
                     boolArrayKeys.Skip(boolArrayStart).Take(boolArrayCount).ToArray(),
                     boolArrayValues.Skip(boolArrayStart).Take(boolArrayCount).ToArray(),
+                    integerArrayKeys.Skip(integerArrayStart).Take(integerArrayCount).ToArray(),
+                    integerArrayValues.Skip(integerArrayStart).Take(integerArrayCount).ToArray(),
                     stringArrayKeys.Skip(stringArrayStart).Take(stringArrayCount).ToArray(),
                     stringArrayValues.Skip(stringArrayStart).Take(stringArrayCount).ToArray(),
                     doubleArrayKeys.Skip(doubleArrayStart).Take(doubleArrayCount).ToArray(),
@@ -196,6 +237,33 @@ namespace PumaGrasshopper
                 {
                     if (defaultValues[i].GetString(key, out string value)) values.Add(value);
                     else values.Add("");
+                }
+
+                return Utils.FromListToTree(values);
+            }
+        }
+
+        public static GH_Structure<GH_Integer> GetDefaultIntegers(string key, AttributesValuesMap[] defaultValues, bool isArray)
+        {
+            if (isArray)
+            {
+                List<List<int>> values = new List<List<int>>(defaultValues.Length);
+
+                for (int i = 0; i < defaultValues.Length; ++i)
+                {
+                    if (defaultValues[i].GetIntegerArray(key, out int[] value)) values.Add(value.ToList());
+                    else values.Add(new List<int>());
+                }
+                return Utils.FromListToTree(values);
+            }
+            else
+            {
+                List<int> values = new List<int>(defaultValues.Length);
+
+                for (int i = 0; i < defaultValues.Length; ++i)
+                {
+                    if (defaultValues[i].GetInteger(key, out int value)) values.Add(value);
+                    else values.Add(0);
                 }
 
                 return Utils.FromListToTree(values);

--- a/PumaGrasshopper/ComponentPuma.cs
+++ b/PumaGrasshopper/ComponentPuma.cs
@@ -488,7 +488,8 @@ namespace PumaGrasshopper
             }
             else if (attributeParam.Type == typeof(GH_Integer))
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Integer arrays are not supported as input parameters, please use Number arrays.");
+                int[] integerList = values.ConvertAll((x) => { x.CastTo<int>(out int i); return i; }).ToArray();
+                MM.AddIntegerArray(name, integerList);
             }
             else if (attributeParam.Type == typeof(GH_Boolean))
             {
@@ -515,7 +516,7 @@ namespace PumaGrasshopper
             else if (attributeParam.Type == typeof(GH_Integer))
             {
                 if (value.CastTo(out int integer))
-                    MM.AddDouble(name, integer);
+                    MM.AddInteger(name, integer);
                 else
                     throw new Exception(Utils.GetCastErrorMessage(name, "integer"));
             }

--- a/PumaGrasshopper/InteropWrapper.cs
+++ b/PumaGrasshopper/InteropWrapper.cs
@@ -107,6 +107,39 @@ namespace PumaGrasshopper
         public double[] ValuesToArray() => Values.ToArray();
     }
 
+    public class InteropWrapperInteger: AttributeInterop
+    {
+        private SimpleArrayInt Values;
+
+        public InteropWrapperInteger(): base()
+        {
+            Keys = new ClassArrayString();
+            Values = new SimpleArrayInt();
+        }
+
+        public InteropWrapperInteger(int[] starts, ref List<string> keys, ref List<int> values): base(starts, keys.Count)
+        {
+            Keys = new ClassArrayString();
+            Values = new SimpleArrayInt(values);
+
+            foreach (var key in keys)
+            {
+                Keys.Add(key);
+            }
+        }
+
+        public new void Dispose()
+        {
+            base.Dispose();
+            Values.Dispose();
+        }
+
+        public IntPtr ValuesPtr() => Values.ConstPointer();
+        public IntPtr ValuesNonConstPtr() => Values.NonConstPointer();
+
+        public int[] ValuesToArray() => Values.ToArray();
+    }
+
     public class InteropWrapperBoolean: AttributeInterop
     {
         private SimpleArrayInt Values;

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -96,15 +96,6 @@ namespace PumaGrasshopper
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern void SetMaterialGenerationOption(bool doGenerate);
 
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern bool GetDefaultValuesBooleanArray(string key, [In, Out] IntPtr pValues, [In, Out] IntPtr pSizes);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern bool GetDefaultValuesNumberArray(string key, [In, Out] IntPtr pValues, [In, Out] IntPtr pSizes);
-
-        [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern bool GetDefaultValuesTextArray(string key, [In, Out] IntPtr pTexts, [In, Out] IntPtr pSizes);
-
         public static GenerationResult Generate(string rpkPath,
             ref RuleAttributesMap MM,
             List<Mesh> initialMeshes)
@@ -419,11 +410,6 @@ namespace PumaGrasshopper
             return defaultValues;
         }
 
-
-        public static void DecodeDefaultValues<T>(int[] starts, string[] keys, T[] values) {
-            
-        }
-
         public static List<String> GetCGAPrintOutput(int initialShapeIndex)
         {
             var printOutput = new ClassArrayString();
@@ -569,113 +555,5 @@ namespace PumaGrasshopper
 
             return version;
         }
-
-        public static List<bool> GetDefaultValuesBoolean(string key)
-        {
-            SimpleArrayInt boolArray = new SimpleArrayInt();
-            var pBoolArray = boolArray.NonConstPointer();
-            bool hasDefault = false; //  GetDefaultValuesBoolean(key, pBoolArray);
-
-            if (!hasDefault) return null;
-
-            List<bool> boolList = new List<int>(boolArray.ToArray()).ConvertAll(x => Convert.ToBoolean(x));
-            boolArray.Dispose();
-
-            return boolList;
-        }
-
-        public static List<double> GetDefaultValuesNumber(string key)
-        {
-            SimpleArrayDouble doubleArray = new SimpleArrayDouble();
-            var pDoubleArray = doubleArray.NonConstPointer();
-            bool hasDefault = false; //GetDefaultValuesNumber(key, pDoubleArray);
-
-            if (!hasDefault) return null;
-
-            List<double> doubleList = new List<double>(doubleArray.ToArray());
-            doubleArray.Dispose();
-
-            return doubleList;
-        }
-
-        public static List<string> GetDefaultValuesText(string key)
-        {
-            ClassArrayString stringArray = new ClassArrayString();
-            var pStringArray = stringArray.NonConstPointer();
-            bool hasDefault = false; // GetDefaultValuesText(key, pStringArray);
-
-            if (!hasDefault) return null;
-
-            List<string> stringList = new List<string>(stringArray.ToArray());
-            stringArray.Dispose();
-
-            return stringList;
-        }
-
-        public static List<List<bool>> GetDefaultValuesBooleanArray(string key)
-        {
-            // Use a single array to pass the data flattened,
-            // and a second array of int to pass the size of the sub-array of each initial shape.
-            SimpleArrayInt valueArray = new SimpleArrayInt();
-            SimpleArrayInt sizeArray = new SimpleArrayInt();
-
-            var pValueArray = valueArray.NonConstPointer();
-            var pSizeArray = sizeArray.NonConstPointer();
-
-            bool hasDefault = GetDefaultValuesBooleanArray(key, pValueArray, pSizeArray);
-
-            if (!hasDefault) return null;
-
-            List<bool> valueList = new List<int>(valueArray.ToArray()).ConvertAll(x => Convert.ToBoolean(x));
-            List<int> sizeList = new List<int>(sizeArray.ToArray());
-
-            valueArray.Dispose();
-            sizeArray.Dispose();
-
-            return Utils.UnflattenList(valueList, sizeList);
-        }
-
-        public static List<List<double>> GetDefaultValuesNumberArray(string key)
-        {
-            SimpleArrayDouble valueArray = new SimpleArrayDouble();
-            SimpleArrayInt sizeArray = new SimpleArrayInt();
-
-            var pValueArray = valueArray.NonConstPointer();
-            var pSizeArray = sizeArray.NonConstPointer();
-
-            bool hasDefault = GetDefaultValuesNumberArray(key, pValueArray, pSizeArray);
-
-            if (!hasDefault) return null;
-
-            List<double> valueList = new List<double>(valueArray.ToArray());
-            List<int> sizeList = new List<int>(sizeArray.ToArray());
-
-            valueArray.Dispose();
-            sizeArray.Dispose();
-
-            return Utils.UnflattenList(valueList, sizeList);
-        }
-
-        public static List<List<string>> GetDefaultValuesTextArray(string key)
-        {
-            ClassArrayString stringArray = new ClassArrayString();
-            SimpleArrayInt sizeArray = new SimpleArrayInt();
-
-            var pStringArray = stringArray.NonConstPointer();
-            var pSizeArray = sizeArray.NonConstPointer();
-
-            bool hasDefault = GetDefaultValuesTextArray(key, pStringArray, pSizeArray);
-
-            if (!hasDefault) return null;
-
-            List<string> stringList = new List<string>(stringArray.ToArray());
-            List<int> sizeList = new List<int>(sizeArray.ToArray());
-
-            stringArray.Dispose();
-            sizeArray.Dispose();
-
-            return Utils.UnflattenList(stringList, sizeList);
-        }
-  
     }
 }

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -134,7 +134,7 @@ namespace PumaGrasshopper
             IntPtr pErrorMsg = errorMsg.NonConstPointer;
 
             // Materials
-            var colorsArray = new SimpleArrayInt();
+            var colorsArray = new SimpleArrayDouble();
             IntPtr pColorsArray = colorsArray.NonConstPointer();
             var matIndices = new SimpleArrayInt();
             IntPtr pMatIndices = matIndices.NonConstPointer();
@@ -206,7 +206,7 @@ namespace PumaGrasshopper
             var meshCountsArray = meshCounts.ToArray();
             var meshesArray = meshes.ToNonConstArray();
             // Materials
-            int[] colors = colorsArray.ToArray();
+            double[] colors = colorsArray.ToArray();
             int[] materialIndices = matIndices.ToArray();
             string[] textureKeys = texKeys.ToArray();
             string[] texturePaths = texPaths.ToArray();
@@ -252,9 +252,9 @@ namespace PumaGrasshopper
 
                     Material mat = new Material()
                     {
-                        DiffuseColor = Color.FromArgb(diffuse[0], diffuse[1], diffuse[2]),
-                        AmbientColor = Color.FromArgb(ambient[0], ambient[1],ambient[2]),
-                        SpecularColor = Color.FromArgb(specular[0], specular[1], specular[2]),
+                        DiffuseColor = Color.FromArgb((int)diffuse[0], (int)diffuse[1], (int)diffuse[2]),
+                        AmbientColor = Color.FromArgb((int)ambient[0], (int)ambient[1], (int)ambient[2]),
+                        SpecularColor = Color.FromArgb((int)specular[0], (int)specular[1], (int)specular[2]),
                         Transparency = 1.0 - opacity,
                         Shine = shininess,
                         FresnelReflections = true,

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -199,6 +199,9 @@ namespace PumaGrasshopper
             boolWrapper.Dispose();
             doubleWrapper.Dispose();
             stringWrapper.Dispose();
+            boolArrayWrapper.Dispose();
+            doubleArrayWrapper.Dispose();
+            stringArrayWrapper.Dispose();
 
             var meshCountsArray = meshCounts.ToArray();
             var meshesArray = meshes.ToNonConstArray();

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -59,12 +59,16 @@ namespace PumaGrasshopper
             int shapeCount,
             [In] IntPtr pBoolStarts, int boolCount,
             [In] IntPtr pBoolKeys, [In] IntPtr pBoolVals,
+            [In] IntPtr pIntegerStarts, int integerCount,
+            [In] IntPtr pIntegerKeys, [In] IntPtr pIntegerVals,
             [In] IntPtr pDoubleStarts, int doubleCount,
             [In] IntPtr pDoubleKeys, [In] IntPtr pDoubleVals,
             [In] IntPtr pStringStarts, int stringCount,
             [In] IntPtr pStringKeys, [In] IntPtr pStringVals,
             [In] IntPtr pBoolArrayStarts, int boolArrayCount,
             [In] IntPtr pBoolArrayKeys, [In] IntPtr pBoolArrayVals,
+            [In] IntPtr pIntegerArrayStarts, int integerArrayCount,
+            [In] IntPtr pIntegerArrayKeys, [In] IntPtr pIntegerArrayVals,
             [In] IntPtr pDoubleArrayStarts, int doubleArrayCount,
             [In] IntPtr pDoubleArrayKeys, [In] IntPtr pDoubleArrayVals,
             [In] IntPtr pStringArrayStarts, int stringArrayCount,
@@ -80,10 +84,12 @@ namespace PumaGrasshopper
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         public static extern bool GetDefaultAttributes(
             string rpk_path, [In] IntPtr pMeshes, 
-            [Out] IntPtr pBoolStarts, [Out] IntPtr pBoolKeys, [Out] IntPtr pBoolVals, 
+            [Out] IntPtr pBoolStarts, [Out] IntPtr pBoolKeys, [Out] IntPtr pBoolVals,
+            [Out] IntPtr pIntegerStarts, [Out] IntPtr pIntegerKeys, [Out] IntPtr pIntegerVals,
             [Out] IntPtr pDoubleStarts, [Out] IntPtr pDoubleKeys, [Out] IntPtr pDoubleVals, 
             [Out] IntPtr pStringStarts, [Out] IntPtr pStringKeys, [Out] IntPtr pStringVals,
             [Out] IntPtr pBoolArrayStarts, [Out] IntPtr pBoolArrayKeys, [Out] IntPtr pBoolArrayVals,
+            [Out] IntPtr pIntegerArrayStarts, [Out] IntPtr pIntegerArrayKeys, [Out] IntPtr pIntegerArrayVals,
             [Out] IntPtr pDoubleArrayStarts, [Out] IntPtr pDoubleArrayKeys, [Out] IntPtr pDoubleArrayVals,
             [Out] IntPtr pStringArrayStarts, [Out] IntPtr pStringArrayKeys, [Out] IntPtr pStringArrayVals);
 
@@ -116,9 +122,11 @@ namespace PumaGrasshopper
 
             var stringWrapper = new InteropWrapperString(MM.GetStringStarts(), ref MM.stringKeys, ref MM.stringValues);
             var boolWrapper = new InteropWrapperBoolean(MM.GetBoolStarts(), ref MM.boolKeys, ref MM.boolValues);
+            var integerWrapper = new InteropWrapperInteger(MM.GetIntegerStarts(), ref MM.integerKeys, ref MM.integerValues);
             var doubleWrapper = new InteropWrapperDouble(MM.GetDoubleStarts(), ref MM.doubleKeys, ref MM.doubleValues);
             var stringArrayWrapper = new InteropWrapperString(MM.GetStringArrayStarts(), ref MM.stringArrayKeys, ref MM.stringArrayValues);
             var boolArrayWrapper = new InteropWrapperString(MM.GetBoolArrayStarts(), ref MM.boolArrayKeys, ref MM.boolArrayValues);
+            var integerArrayWrapper = new InteropWrapperString(MM.GetIntegerArrayStarts(), ref MM.integerArrayKeys, ref MM.integerArrayValues);
             var doubleArrayWrapper = new InteropWrapperString(MM.GetDoubleArrayStarts(), ref MM.doubleArrayKeys, ref MM.doubleArrayValues);
 
             StringWrapper errorMsg = new StringWrapper("");
@@ -153,6 +161,10 @@ namespace PumaGrasshopper
                      boolWrapper.Count,
                      boolWrapper.KeysPtr(),
                      boolWrapper.ValuesPtr(),
+                     integerWrapper.StartsPtr(),
+                     integerWrapper.Count,
+                     integerWrapper.KeysPtr(),
+                     integerWrapper.ValuesPtr(),
                      doubleWrapper.StartsPtr(),
                      doubleWrapper.Count,
                      doubleWrapper.KeysPtr(),
@@ -165,6 +177,10 @@ namespace PumaGrasshopper
                      boolArrayWrapper.Count,
                      boolArrayWrapper.KeysPtr(),
                      boolArrayWrapper.ValuesPtr(),
+                     integerArrayWrapper.StartsPtr(),
+                     integerArrayWrapper.Count,
+                     integerArrayWrapper.KeysPtr(),
+                     integerArrayWrapper.ValuesPtr(),
                      doubleArrayWrapper.StartsPtr(),
                      doubleArrayWrapper.Count,
                      doubleArrayWrapper.KeysPtr(),
@@ -188,9 +204,11 @@ namespace PumaGrasshopper
 
             initialMeshesArray.Dispose();
             boolWrapper.Dispose();
+            integerWrapper.Dispose();
             doubleWrapper.Dispose();
             stringWrapper.Dispose();
             boolArrayWrapper.Dispose();
+            integerArrayWrapper.Dispose();
             doubleArrayWrapper.Dispose();
             stringArrayWrapper.Dispose();
 
@@ -373,17 +391,20 @@ namespace PumaGrasshopper
 
             var stringWrapper = new InteropWrapperString();
             var boolWrapper = new InteropWrapperBoolean();
+            var integerWrapper = new InteropWrapperInteger();
             var doubleWrapper = new InteropWrapperDouble();
             var stringArrayWrapper = new InteropWrapperString();
             var boolArrayWrapper = new InteropWrapperString();
             var doubleArrayWrapper = new InteropWrapperString();
-
+            var integerArrayWrapper = new InteropWrapperString();
 
             bool status = GetDefaultAttributes(rulePkg, initialMeshesArray.ConstPointer(), 
                 boolWrapper.StartsNonConstPtr(), boolWrapper.KeysNonConstPtr(), boolWrapper.ValuesNonConstPtr(),
+                integerWrapper.StartsNonConstPtr(), integerWrapper.KeysNonConstPtr(), integerWrapper.ValuesNonConstPtr(),
                 doubleWrapper.StartsNonConstPtr(), doubleWrapper.KeysNonConstPtr(), doubleWrapper.ValuesNonConstPtr(),
                 stringWrapper.StartsNonConstPtr(), stringWrapper.KeysNonConstPtr(), stringWrapper.ValuesNonConstPtr(),
                 boolArrayWrapper.StartsNonConstPtr(), boolArrayWrapper.KeysNonConstPtr(), boolArrayWrapper.ValuesNonConstPtr(),
+                integerArrayWrapper.StartsNonConstPtr(), integerArrayWrapper.KeysNonConstPtr(), integerArrayWrapper.ValuesNonConstPtr(),
                 doubleArrayWrapper.StartsNonConstPtr(), doubleArrayWrapper.KeysNonConstPtr(), doubleArrayWrapper.ValuesNonConstPtr(),
                 stringArrayWrapper.StartsNonConstPtr(), stringArrayWrapper.KeysNonConstPtr(), stringArrayWrapper.ValuesNonConstPtr());
 
@@ -391,21 +412,27 @@ namespace PumaGrasshopper
             {
                 stringWrapper.Dispose();
                 boolWrapper.Dispose();
+                integerWrapper.Dispose();
                 doubleWrapper.Dispose();
                 stringArrayWrapper.Dispose();
                 doubleArrayWrapper.Dispose();
                 boolArrayWrapper.Dispose();
+                integerArrayWrapper.Dispose();
                 return null;
             }
 
-            var defaultValues = AttributesValuesMap.FromInteropWrappers(initialMeshes.Count, ref boolWrapper, ref stringWrapper, ref doubleWrapper, ref boolArrayWrapper, ref stringArrayWrapper, ref doubleArrayWrapper);
+            AttributesValuesMap[] defaultValues = AttributesValuesMap.FromInteropWrappers(
+                initialMeshes.Count, ref boolWrapper, ref integerWrapper, ref stringWrapper, ref doubleWrapper,
+                ref boolArrayWrapper, ref integerArrayWrapper, ref stringArrayWrapper, ref doubleArrayWrapper);
             
             stringWrapper.Dispose();
             boolWrapper.Dispose();
+            integerWrapper.Dispose();
             doubleWrapper.Dispose();
             stringArrayWrapper.Dispose();
             doubleArrayWrapper.Dispose();
             boolArrayWrapper.Dispose();
+            integerArrayWrapper.Dispose();
 
             return defaultValues;
         }

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -55,7 +55,7 @@ namespace PumaGrasshopper
         public static extern bool InitializeRhinoPRT();
 
         [DllImport(dllName: PUMA_RHINO_LIBRARY, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
-        public static extern int Generate(string rpk_path, [Out] IntPtr errorMsg,
+        public static extern int Generate(string rpk_path,
             int shapeCount,
             [In] IntPtr pBoolStarts, int boolCount,
             [In] IntPtr pBoolKeys, [In] IntPtr pBoolVals,
@@ -129,9 +129,6 @@ namespace PumaGrasshopper
             var integerArrayWrapper = new InteropWrapperString(MM.GetIntegerArrayStarts(), ref MM.integerArrayKeys, ref MM.integerArrayValues);
             var doubleArrayWrapper = new InteropWrapperString(MM.GetDoubleArrayStarts(), ref MM.doubleArrayKeys, ref MM.doubleArrayValues);
 
-            StringWrapper errorMsg = new StringWrapper("");
-            IntPtr pErrorMsg = errorMsg.NonConstPointer;
-
             // Materials
             var colorsArray = new SimpleArrayDouble();
             IntPtr pColorsArray = colorsArray.NonConstPointer();
@@ -155,7 +152,6 @@ namespace PumaGrasshopper
             IntPtr pReportStringArray = reportStringArray.NonConstPointer();
 
             Generate(rpkPath,
-                     pErrorMsg,
                      initialMeshes.Count,
                      boolWrapper.StartsPtr(),
                      boolWrapper.Count,
@@ -314,7 +310,8 @@ namespace PumaGrasshopper
 
                     textureOffset += texCount;
 
-                    materials[meshId] = new GH_Material(Rhino.Render.RenderMaterial.CreateBasicMaterial(mat));
+                    materials[meshId] = new GH_Material(Rhino.Render.RenderMaterial.CreateBasicMaterial(mat, Rhino.RhinoDoc.ActiveDoc));
+                    
                 }
 
                 id += meshCount + 1;

--- a/PumaGrasshopper/PRTWrapper.cs
+++ b/PumaGrasshopper/PRTWrapper.cs
@@ -252,9 +252,9 @@ namespace PumaGrasshopper
 
                     Material mat = new Material()
                     {
-                        DiffuseColor = Color.FromArgb((int)diffuse[0], (int)diffuse[1], (int)diffuse[2]),
-                        AmbientColor = Color.FromArgb((int)ambient[0], (int)ambient[1], (int)ambient[2]),
-                        SpecularColor = Color.FromArgb((int)specular[0], (int)specular[1], (int)specular[2]),
+                        DiffuseColor = Utils.ColorFromRGB(diffuse),
+                        AmbientColor = Utils.ColorFromRGB(ambient),
+                        SpecularColor = Utils.ColorFromRGB(specular),
                         Transparency = 1.0 - opacity,
                         Shine = shininess,
                         FresnelReflections = true,

--- a/PumaGrasshopper/RuleAttribute.cs
+++ b/PumaGrasshopper/RuleAttribute.cs
@@ -64,7 +64,6 @@ namespace PumaGrasshopper
                         return param_bool;
                     }
                 case Annotations.AnnotationArgumentType.AAT_FLOAT_ARRAY:
-                case Annotations.AnnotationArgumentType.AAT_INT:
                 case Annotations.AnnotationArgumentType.AAT_FLOAT:
                     {
                         var param_number = new AttributeParameter.Number(mAnnotations, mGroup, IsArray())
@@ -78,6 +77,21 @@ namespace PumaGrasshopper
                         param_number.SetPersistentData(AttributesValuesMap.GetDefaultDoubles(mFullName, defaultValuesMap, IsArray()));
                         
                         return param_number;
+                    }
+                case Annotations.AnnotationArgumentType.AAT_INT:
+                case Annotations.AnnotationArgumentType.AAT_INT_ARRAY:
+                    {
+                        var param_int = new AttributeParameter.Number(mAnnotations, mGroup, IsArray())
+                        {
+                            Name = mFullName,
+                            NickName = mNickname,
+                            Description = GetDescriptions(),
+                            Optional = true,
+                            Access = GetAccess()
+                        };
+                        param_int.SetPersistentData(AttributesValuesMap.GetDefaultIntegers(mFullName, defaultValuesMap, IsArray()));
+
+                        return param_int;
                     }
                 case Annotations.AnnotationArgumentType.AAT_STR_ARRAY:
                 case Annotations.AnnotationArgumentType.AAT_STR:

--- a/PumaGrasshopper/RuleAttributesMap.cs
+++ b/PumaGrasshopper/RuleAttributesMap.cs
@@ -9,23 +9,29 @@ namespace PumaGrasshopper
     public class RuleAttributesMap
     {
         private List<int> boolStarts = new List<int>();
+        private List<int> integerStarts = new List<int>();
         private List<int> doubleStarts = new List<int>();
         private List<int> stringStarts = new List<int>();
         private List<int> boolArrayStarts = new List<int>();
+        private List<int> integerArrayStarts = new List<int>();
         private List<int> doubleArrayStarts = new List<int>();
         private List<int> stringArrayStarts = new List<int>();
 
         public List<string> boolKeys = new List<string>();
+        public List<string> integerKeys = new List<string>();
         public List<string> doubleKeys = new List<string>();
         public List<string> stringKeys = new List<string>();
         public List<string> boolArrayKeys = new List<string>();
+        public List<string> integerArrayKeys = new List<string>();
         public List<string> doubleArrayKeys = new List<string>();
         public List<string> stringArrayKeys = new List<string>();
 
         public List<bool> boolValues = new List<bool>();
+        public List<int> integerValues = new List<int>();
         public List<double> doubleValues = new List<double>();
         public List<string> stringValues = new List<string>();
         public List<string> boolArrayValues = new List<string>();
+        public List<string> integerArrayValues = new List<string>();
         public List<string> doubleArrayValues = new List<string>();
         public List<string> stringArrayValues = new List<string>();
 
@@ -34,9 +40,11 @@ namespace PumaGrasshopper
         public void StartNewSection()
         {
             boolStarts.Add(boolKeys.Count);
+            integerStarts.Add(integerKeys.Count);
             doubleStarts.Add(doubleKeys.Count);
             stringStarts.Add(stringKeys.Count);
             boolArrayStarts.Add(boolArrayKeys.Count);
+            integerArrayStarts.Add(integerArrayKeys.Count);
             doubleArrayStarts.Add(doubleArrayKeys.Count);
             stringArrayStarts.Add(stringArrayKeys.Count);
         }
@@ -59,10 +67,22 @@ namespace PumaGrasshopper
             boolValues.Add(value);
         }
 
+        public void AddInteger(string key, int value)
+        {
+            integerKeys.Add(key);
+            integerValues.Add(value);
+        }
+
         public void AddBoolArray(string key, bool[] values)
         {
             boolArrayKeys.Add(key);
             boolArrayValues.Add(Utils.ToCeArray(values));
+        }
+
+        public void AddIntegerArray(string key, int[] values)
+        {
+            integerArrayKeys.Add(key);
+            integerArrayValues.Add(Utils.ToCeArray(values));
         }
 
         public void AddDoubleArray(string key, double[] values)
@@ -79,10 +99,12 @@ namespace PumaGrasshopper
 
         public int[] GetStringStarts() => stringStarts.ToArray();
         public int[] GetBoolStarts() => boolStarts.ToArray();
+        public int[] GetIntegerStarts() => integerStarts.ToArray();
         public int[] GetDoubleStarts() => doubleStarts.ToArray();
 
         public int[] GetStringArrayStarts() => stringArrayStarts.ToArray();
         public int[] GetDoubleArrayStarts() => doubleArrayStarts.ToArray();
         public int[] GetBoolArrayStarts() => boolArrayStarts.ToArray();
+        public int[] GetIntegerArrayStarts() => integerArrayStarts.ToArray();
     }
 }

--- a/PumaGrasshopper/Utils.cs
+++ b/PumaGrasshopper/Utils.cs
@@ -127,6 +127,7 @@ namespace PumaGrasshopper
 
         public static string[] StringFromCeArray(string values) => values.Split(':');
         public static bool[] BoolFromCeArray(string values) => Array.ConvertAll(values.Split(':'), value => Convert.ToBoolean(value));
+        public static int[] IntegerFromCeArray(string values) => Array.ConvertAll(values.Split(':'), value => Convert.ToInt32(value));
         public static double[] DoubleFromCeArray(string values) => Array.ConvertAll(values.Split(':'), value => Convert.ToDouble(value));
 
         public static GH_Structure<GH_Number> FromListToTree(List<double> valueList)
@@ -148,6 +149,17 @@ namespace PumaGrasshopper
             }
             return tree;
         }
+
+        public static GH_Structure<GH_Integer> FromListToTree(List<int> valueList)
+        {
+            GH_Structure<GH_Integer> tree = new GH_Structure<GH_Integer>();
+            for(int i = 0; i < valueList.Count; ++i)
+            {
+                tree.Insert(new GH_Integer(valueList[i]), new GH_Path(i), 0);
+            }
+            return tree;
+        }
+
         public static GH_Structure<GH_String> FromListToTree(List<string> valueList)
         {
             GH_Structure<GH_String> tree = new GH_Structure<GH_String>();
@@ -174,6 +186,16 @@ namespace PumaGrasshopper
             for (int i = 0; i < valueList.Count; ++i)
             {
                 tree.AppendRange(valueList[i].ConvertAll(val => new GH_Boolean(val)), new GH_Path(i));
+            }
+            return tree;
+        }
+
+        public static GH_Structure<GH_Integer> FromListToTree(List<List<int>> valueList)
+        {
+            GH_Structure<GH_Integer> tree = new GH_Structure<GH_Integer>();
+            for(int i = 0; i < valueList.Count; ++i)
+            {
+                tree.AppendRange(valueList[i].ConvertAll(val => new GH_Integer(val)), new GH_Path(i));
             }
             return tree;
         }

--- a/PumaGrasshopper/Utils.cs
+++ b/PumaGrasshopper/Utils.cs
@@ -229,6 +229,11 @@ namespace PumaGrasshopper
             return ColorTranslator.FromHtml(hexColor);
         }
 
+        public static Color ColorFromRGB(double[] colorArray)
+        {
+            return Color.FromArgb((int)(colorArray[0] * 255), (int)(colorArray[1] * 255), (int)(colorArray[2] * 255));
+        }
+
         public static bool IsInteger(double d)
         {
             return Math.Abs(d % 1) <= (Double.Epsilon * 100);

--- a/PumaRhino/ModelGenerator.cpp
+++ b/PumaRhino/ModelGenerator.cpp
@@ -396,8 +396,8 @@ void ModelGenerator::extractMainShapeAttributes(pcu::AttributeMapBuilderPtr& aBu
 		if (convertShapeAttr->hasKey(L"startRule") &&
 		    convertShapeAttr->getType(L"startRule") == prt::AttributeMap::PT_STRING)
 			startRule = convertShapeAttr->getString(L"startRule");
-		if (convertShapeAttr->hasKey(SEED_KEY) && convertShapeAttr->getType(SEED_KEY) == prt::AttributeMap::PT_FLOAT)
-			seed = convertShapeAttr->getFloat(SEED_KEY);
+		if (convertShapeAttr->hasKey(SEED_KEY) && convertShapeAttr->getType(SEED_KEY) == prt::AttributeMap::PT_INT)
+			seed = convertShapeAttr->getInt(SEED_KEY);
 		if (convertShapeAttr->hasKey(L"shapeName") &&
 		    convertShapeAttr->getType(L"shapeName") == prt::AttributeMap::PT_STRING)
 			shapeName = convertShapeAttr->getString(L"shapeName");

--- a/PumaRhino/ModelGenerator.cpp
+++ b/PumaRhino/ModelGenerator.cpp
@@ -396,8 +396,8 @@ void ModelGenerator::extractMainShapeAttributes(pcu::AttributeMapBuilderPtr& aBu
 		if (convertShapeAttr->hasKey(L"startRule") &&
 		    convertShapeAttr->getType(L"startRule") == prt::AttributeMap::PT_STRING)
 			startRule = convertShapeAttr->getString(L"startRule");
-		if (convertShapeAttr->hasKey(SEED_KEY) && convertShapeAttr->getType(SEED_KEY) == prt::AttributeMap::PT_INT)
-			seed = convertShapeAttr->getInt(SEED_KEY);
+		if (convertShapeAttr->hasKey(SEED_KEY) && convertShapeAttr->getType(SEED_KEY) == prt::AttributeMap::PT_FLOAT)
+			seed = convertShapeAttr->getFloat(SEED_KEY);
 		if (convertShapeAttr->hasKey(L"shapeName") &&
 		    convertShapeAttr->getType(L"shapeName") == prt::AttributeMap::PT_STRING)
 			shapeName = convertShapeAttr->getString(L"shapeName");

--- a/PumaRhino/PumaGrasshopperAPI.cpp
+++ b/PumaRhino/PumaGrasshopperAPI.cpp
@@ -58,7 +58,7 @@ RHINOPRT_API void ShutdownRhinoPRT() {
 	RhinoPRT::get().ShutdownRhinoPRT();
 }
 
-RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
+RHINOPRT_API bool Generate(const wchar_t* rpk_path,
 						   // rule attributes
 						   const int shapeCount,
 						   ON_SimpleArray<int>* pBoolStarts, const int boolCount,
@@ -181,7 +181,7 @@ RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
 			}
 
 			// Materials
-			pMatIndices->Append(meshBundle.size());
+			pMatIndices->Append((int)meshBundle.size());
 
 			const auto& materials = models[i]->getMaterials();
 			for (const auto& material : materials) {
@@ -192,7 +192,7 @@ RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
 				pColorsArray->Append(matAttributes.mOpacity);
 				pColorsArray->Append(matAttributes.mShininess);
 
-				pMatIndices->Append(matAttributes.mTexturePaths.size());
+				pMatIndices->Append((int)matAttributes.mTexturePaths.size());
 
 				for (auto& texture : matAttributes.mTexturePaths) {
 
@@ -287,7 +287,7 @@ RHINOPRT_API int GetRuleAttributes(const wchar_t* rpk_path, ON_ClassArray<ON_wSt
 			pAttributesBuffer->Append({});
 
 		pAttributesTypes->Append((int)attribute->mType);
-		pAttributesTypes->Append(attribute->mAnnotations.size());
+		pAttributesTypes->Append((int)attribute->mAnnotations.size());
 
 		for (const auto& annot : attribute->mAnnotations) {
 			pBaseAnnotations->Append((int)annot->getType());
@@ -308,7 +308,7 @@ RHINOPRT_API int GetRuleAttributes(const wchar_t* rpk_path, ON_ClassArray<ON_wSt
 
 							const std::vector<double> annotEnum =
 							        dynamic_cast<AnnotationEnum<double>*>(annot.get())->getAnnotArguments();
-							pBaseAnnotations->Append(annotEnum.size());
+							pBaseAnnotations->Append((int)annotEnum.size());
 							std::for_each(annotEnum.begin(), annotEnum.end(),
 							              [pDoubleAnnotations](double value) { pDoubleAnnotations->Append(value); });
 							break;	
@@ -317,7 +317,7 @@ RHINOPRT_API int GetRuleAttributes(const wchar_t* rpk_path, ON_ClassArray<ON_wSt
 
 							const std::vector<std::wstring> annotEnum =
 							        dynamic_cast<AnnotationEnum<std::wstring>*>(annot.get())->getAnnotArguments();
-							pBaseAnnotations->Append(annotEnum.size());
+							pBaseAnnotations->Append((int)annotEnum.size());
 							std::for_each(annotEnum.begin(), annotEnum.end(), [pStringAnnotations](std::wstring value) {
 								pStringAnnotations->Append(ON_wString(value.c_str()));
 							});

--- a/PumaRhino/PumaGrasshopperAPI.cpp
+++ b/PumaRhino/PumaGrasshopperAPI.cpp
@@ -64,6 +64,9 @@ RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
 						   ON_SimpleArray<int>* pBoolStarts, const int boolCount,
 						   ON_ClassArray<ON_wString>* pBoolKeys, ON_SimpleArray<int>* pBoolVals,
 
+						   ON_SimpleArray<int>* pIntegerStarts, const int integerCount,
+						   ON_ClassArray<ON_wString>* pIntegerKeys, ON_SimpleArray<int32_t>* pIntegerVals,
+
 						   ON_SimpleArray<int>* pDoubleStarts, const int doubleCount,
 						   ON_ClassArray<ON_wString>* pDoubleKeys, ON_SimpleArray<double>* pDoubleVals,
 
@@ -72,6 +75,9 @@ RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
 
 						   ON_SimpleArray<int>* pBoolArrayStarts, const int boolArrayCount,
                            ON_ClassArray<ON_wString>* pBoolArrayKeys, ON_ClassArray<ON_wString>* pBoolArrayVals,
+
+						   ON_SimpleArray<int>* pIntegerArrayStarts, const int integerArrayCount,
+						   ON_ClassArray<ON_wString>* pIntegerArrayKeys, ON_ClassArray<ON_wString>* pIntegerArrayVals,
 
 						   ON_SimpleArray<int>* pDoubleArrayStarts, const int doubleArrayCount,
                            ON_ClassArray<ON_wString>* pDoubleArrayKeys, ON_ClassArray<ON_wString>* pDoubleArrayVals,
@@ -113,42 +119,52 @@ RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
 	for (int i = 0; i < shapeCount; ++i) {
 		// by initial shape
 		int indexStartBool = *pBoolStarts->At(i);
+		int indexStartInteger = *pIntegerStarts->At(i);
 		int indexStartDouble = *pDoubleStarts->At(i);
 		int indexStartString = *pStringStarts->At(i);
 		int indexStartBoolArray = *pBoolArrayStarts->At(i);
+		int indexStartIntegerArray = *pIntegerArrayStarts->At(i);
 		int indexStartDoubleArray = *pDoubleArrayStarts->At(i);
 		int indexStartStringArray = *pStringArrayStarts->At(i);
 
 		bool notLastShape = i < shapeCount - 1;
 
 		int nextIndexStartBool = notLastShape ? *pBoolStarts->At(i + 1) : boolCount;
+		int nextIndexStartInteger = notLastShape ? *pIntegerStarts->At(i + 1) : integerCount;
 		int nextIndexStartDouble = notLastShape ? *pDoubleStarts->At(i + 1) : doubleCount;
 		int nextIndexStartString = notLastShape ? *pStringStarts->At(i + 1) : stringCount;
 		int nextIndexStartBoolArray = notLastShape ? *pBoolArrayStarts->At(i + 1) : boolArrayCount;
+		int nextIndexStartIntegerArray = notLastShape ? *pIntegerArrayStarts->At(i + 1) : integerArrayCount;
 		int nextIndexStartDoubleArray = notLastShape ? *pDoubleArrayStarts->At(i + 1) : doubleArrayCount;
 		int nextIndexStartStringArray = notLastShape ? *pStringArrayStarts->At(i + 1) : stringArrayCount;
 
 		int boolAttrCount = nextIndexStartBool - indexStartBool;
+		int integerAttrCount = nextIndexStartInteger - indexStartInteger;
 		int doubleAttrCount = nextIndexStartDouble - indexStartDouble;
 		int stringAttrCount = nextIndexStartString - indexStartString;
 		int boolAttrArrayCount = nextIndexStartBoolArray - indexStartBoolArray;
+		int integerAttrArrayCount = nextIndexStartIntegerArray - indexStartIntegerArray;
 		int doubleAttrArrayCount = nextIndexStartDoubleArray - indexStartDoubleArray;
 		int stringAttrArrayCount = nextIndexStartStringArray - indexStartStringArray;
 
 		pcu::unpackBoolAttributes(indexStartBool, boolAttrCount, pBoolKeys, pBoolVals, aBuilders[i]);
+		pcu::unpackIntegerAttributes(indexStartInteger, integerAttrCount, pIntegerKeys, pIntegerVals, aBuilders[i]);
 		pcu::unpackDoubleAttributes(indexStartDouble, doubleAttrCount, pDoubleKeys, pDoubleVals, aBuilders[i]);
 		pcu::unpackStringAttributes(indexStartString, stringAttrCount, pStringKeys, pStringVals,
 		                      aBuilders[i], false);
 		pcu::unpackBoolArrayAttributes(indexStartBoolArray, boolAttrArrayCount, pBoolArrayKeys, pBoolArrayVals,
 		                           aBuilders[i]);
+		pcu::unpackIntegerArrayAttributes(indexStartIntegerArray, integerAttrArrayCount, pIntegerArrayKeys, pIntegerArrayVals, aBuilders[i]);
 		pcu::unpackDoubleArrayAttributes(indexStartDoubleArray, doubleAttrArrayCount, pDoubleArrayKeys, pDoubleArrayVals, aBuilders[i]);
 		pcu::unpackStringAttributes(indexStartStringArray, stringAttrArrayCount, pStringArrayKeys, pStringArrayVals,
 		                            aBuilders[i], true);
 
 		indexStartBool += boolAttrCount;
+		indexStartInteger += integerAttrCount;
 		indexStartDouble += doubleAttrCount;
 		indexStartString += stringAttrCount;
 		indexStartBoolArray += boolAttrArrayCount;
+		indexStartIntegerArray += integerAttrArrayCount;
 		indexStartDoubleArray += doubleAttrArrayCount;
 		indexStartStringArray += stringAttrArrayCount;
 	}
@@ -270,7 +286,7 @@ RHINOPRT_API int GetRuleAttributes(const wchar_t* rpk_path, ON_ClassArray<ON_wSt
 		else
 			pAttributesBuffer->Append({});
 
-		pAttributesTypes->Append(attribute->mType);
+		pAttributesTypes->Append((int)attribute->mType);
 		pAttributesTypes->Append(attribute->mAnnotations.size());
 
 		for (const auto& annot : attribute->mAnnotations) {
@@ -322,9 +338,11 @@ RHINOPRT_API int GetRuleAttributes(const wchar_t* rpk_path, ON_ClassArray<ON_wSt
 
 RHINOPRT_API bool GetDefaultAttributes(	const wchar_t* rpk_path, ON_SimpleArray<const ON_Mesh*>* pMesh,
 										ON_SimpleArray<int>* pBoolStarts, ON_ClassArray<ON_wString>* pBoolKeys, ON_SimpleArray<int>* pBoolVals,
+										ON_SimpleArray<int>* pIntegerStarts, ON_ClassArray<ON_wString>* pIntegerKeys, ON_SimpleArray<int32_t>* pIntegerVals,
 										ON_SimpleArray<int>* pDoubleStarts, ON_ClassArray<ON_wString>* pDoubleKeys, ON_SimpleArray<double>* pDoubleVals,
 										ON_SimpleArray<int>* pStringStarts, ON_ClassArray<ON_wString>* pStringKeys, ON_ClassArray<ON_wString>* pStringVals,
 										ON_SimpleArray<int>* pBoolArrayStarts, ON_ClassArray<ON_wString>* pBoolArrayKeys, ON_ClassArray<ON_wString>* pBoolArrayVals,
+										ON_SimpleArray<int>* pIntegerArrayStarts, ON_ClassArray<ON_wString>* pIntegerArrayKeys, ON_ClassArray<ON_wString>* pIntegerArrayVals,
 										ON_SimpleArray<int>* pDoubleArrayStarts, ON_ClassArray<ON_wString>* pDoubleArrayKeys, ON_ClassArray<ON_wString>* pDoubleArrayVals,
 										ON_SimpleArray<int>* pStringArrayStarts, ON_ClassArray<ON_wString>* pStringArrayKeys, ON_ClassArray<ON_wString>* pStringArrayVals) {
 	if (rpk_path == nullptr || pMesh == nullptr || pMesh->Count() == 0)
@@ -351,9 +369,11 @@ RHINOPRT_API bool GetDefaultAttributes(	const wchar_t* rpk_path, ON_SimpleArray<
 
 		// Set starting indices for current shape
 		pBoolStarts->Append(pBoolKeys->Count());
+		pIntegerStarts->Append(pIntegerKeys->Count());
 		pDoubleStarts->Append(pDoubleKeys->Count());
 		pStringStarts->Append(pStringKeys->Count());
 		pBoolArrayStarts->Append(pBoolArrayKeys->Count());
+		pIntegerArrayStarts->Append(pIntegerArrayKeys->Count());
 		pDoubleArrayStarts->Append(pDoubleArrayKeys->Count());
 		pStringArrayStarts->Append(pStringArrayKeys->Count());
 
@@ -385,8 +405,8 @@ RHINOPRT_API bool GetDefaultAttributes(	const wchar_t* rpk_path, ON_SimpleArray<
 			case prt::AttributeMap::PrimitiveType::PT_INT: {
 				const int value = shapeDefaultValues->getInt(key, &status);
 				if (status == prt::Status::STATUS_OK) {
-					pDoubleKeys->Append(key);
-					pDoubleVals->Append(value);
+					pIntegerKeys->Append(key);
+					pIntegerVals->Append(value);
 				}
 				break;
 			}
@@ -418,10 +438,10 @@ RHINOPRT_API bool GetDefaultAttributes(	const wchar_t* rpk_path, ON_SimpleArray<
 			}
 			case prt::AttributeMap::PrimitiveType::PT_INT_ARRAY: {
 				size_t count(0);
-				const int* const value = shapeDefaultValues->getIntArray(key, &count, &status);
+				const int32_t* const value = shapeDefaultValues->getIntArray(key, &count, &status);
 				if (status == prt::Status::STATUS_OK) {
-					pDoubleArrayKeys->Append(key);
-					pDoubleArrayVals->Append(pcu::toCeArray(value, count).c_str());
+					pIntegerArrayKeys->Append(key);
+					pIntegerArrayVals->Append(pcu::toCeArray(value, count).c_str());
 				}
 				break;
 			}

--- a/PumaRhino/PumaGrasshopperAPI.cpp
+++ b/PumaRhino/PumaGrasshopperAPI.cpp
@@ -87,7 +87,7 @@ RHINOPRT_API bool Generate(const wchar_t* rpk_path, ON_wString* errorMsg,
                            ON_SimpleArray<ON_Mesh*>* pMeshArray,
 							
 						   // Materials,
-                           ON_SimpleArray<int>* pColorsArray, ON_SimpleArray<int>* pMatIndices,
+                           ON_SimpleArray<double>* pColorsArray, ON_SimpleArray<int>* pMatIndices,
                            ON_ClassArray<ON_wString>* pTexKeys, ON_ClassArray<ON_wString>* pTexPaths,
 	
 						   // Reports

--- a/PumaRhino/utils.cpp
+++ b/PumaRhino/utils.cpp
@@ -57,7 +57,7 @@ void checkLastError(const std::string& exceptionPrefix) {
 namespace pcu {
 
 ShapeAttributes::ShapeAttributes(pcu::RuleFileInfoPtr ruleFileInfo, const std::wstring rulef, const std::wstring startRl,
-                                 const std::wstring shapeN, int seed)
+                                 const std::wstring shapeN, int32_t seed)
     : ruleFileInfo(std::move(ruleFileInfo)), ruleFile(rulef), startRule(startRl), shapeName(shapeN), seed(seed) {}
 
 // location of RhinoPRT shared library
@@ -394,6 +394,15 @@ void unpackBoolAttributes(int start, int count, ON_ClassArray<ON_wString>* keys,
 	}
 }
 
+void unpackIntegerAttributes(int start, int count, ON_ClassArray<ON_wString>* keys, ON_SimpleArray<int32_t>* values,
+	AttributeMapBuilderPtr& aBuilder) {
+	for (int i = start; i < start + count; ++i) {
+		const std::wstring key(keys->At(i)->Array());
+		const int32_t value(*values->At(i));
+		pcu::fillMapBuilder(key, value, aBuilder);
+	}
+}
+
 void unpackDoubleArrayAttributes(int start, int count, ON_ClassArray<ON_wString>* keys, ON_ClassArray<ON_wString>* values,
                            AttributeMapBuilderPtr& aBuilder) {
 	for (int i = start; i < start + count; ++i) {
@@ -410,6 +419,15 @@ void unpackBoolArrayAttributes(int start, int count, ON_ClassArray<ON_wString>* 
 		const std::wstring key(keys->At(i)->Array());
 		const auto vArray = pcu::fromCeArray(values->At(i)->Array());
 		pcu::fillArrayMapBuilder<bool>(key, vArray, aBuilder);
+	}
+}
+
+void unpackIntegerArrayAttributes(int start, int count, ON_ClassArray<ON_wString>* keys,
+	ON_ClassArray<ON_wString>* values, AttributeMapBuilderPtr& aBuilder) {
+	for (int i = start; i < start + count; ++i) {
+		const std::wstring key(keys->At(i)->Array());
+		const auto vArray = pcu::fromCeArray(values->At(i)->Array());
+		pcu::fillArrayMapBuilder<int>(key, vArray, aBuilder);
 	}
 }
 

--- a/PumaRhino/utils.cpp
+++ b/PumaRhino/utils.cpp
@@ -215,9 +215,9 @@ void appendToRhinoString(ON_wString& rhinoString, const std::wstring& appendee) 
 }
 
 void appendColor(const ON_Color& color, ON_SimpleArray<double>* pArray){
-	pArray->Append(color.Red());
-	pArray->Append(color.Green());
-	pArray->Append(color.Blue());
+	pArray->Append(color.FractionRed());
+	pArray->Append(color.FractionGreen());
+	pArray->Append(color.FractionBlue());
 }
 
 std::string percentEncode(const std::string& utf8String) {

--- a/PumaRhino/utils.cpp
+++ b/PumaRhino/utils.cpp
@@ -412,7 +412,6 @@ void unpackDoubleArrayAttributes(int start, int count, ON_ClassArray<ON_wString>
 	}
 }
 
-
 void unpackBoolArrayAttributes(int start, int count, ON_ClassArray<ON_wString>* keys, ON_ClassArray<ON_wString>* values,
                               AttributeMapBuilderPtr& aBuilder) {
 	for (int i = start; i < start + count; ++i) {

--- a/PumaRhino/utils.cpp
+++ b/PumaRhino/utils.cpp
@@ -390,7 +390,7 @@ void unpackBoolAttributes(int start, int count, ON_ClassArray<ON_wString>* keys,
 		const std::wstring key(keys->At(i)->Array());
 
 		const int value(*values->At(i));
-		pcu::fillMapBuilder<bool>(key, static_cast<bool>(value), aBuilder);
+		pcu::fillMapBuilder(key, static_cast<bool>(value), aBuilder);
 	}
 }
 

--- a/PumaRhino/utils.cpp
+++ b/PumaRhino/utils.cpp
@@ -362,7 +362,7 @@ const std::wstring toCeArray(const double* values, size_t count) {
 	return serializedArray;
 }
 
-const std::wstring toCeArray(const int* values, size_t count) {
+const std::wstring toCeArray(const int32_t* values, size_t count) {
 	std::wstring serializedArray;
 	for (size_t i = 0; i < count; ++i) {
 		serializedArray +=  std::to_wstring(values[i]) + CE_ARRAY_DELIMITER;

--- a/PumaRhino/utils.cpp
+++ b/PumaRhino/utils.cpp
@@ -214,7 +214,7 @@ void appendToRhinoString(ON_wString& rhinoString, const std::wstring& appendee) 
 	rhinoString += appendee.c_str();
 }
 
-void appendColor(const ON_Color& color, ON_SimpleArray<int>* pArray){
+void appendColor(const ON_Color& color, ON_SimpleArray<double>* pArray){
 	pArray->Append(color.Red());
 	pArray->Append(color.Green());
 	pArray->Append(color.Blue());

--- a/PumaRhino/utils.h
+++ b/PumaRhino/utils.h
@@ -113,7 +113,7 @@ std::string toUTF8FromUTF16(const std::wstring& utf16String);
 std::string toUTF8FromOSNarrow(const std::string& osString);
 
 void appendToRhinoString(ON_wString& rhinoString, const std::wstring& appendee);
-void appendColor(const ON_Color& color, ON_SimpleArray<int>* pArray);
+void appendColor(const ON_Color& color, ON_SimpleArray<double>* pArray);
 
 std::string percentEncode(const std::string& utf8String);
 std::string toFileURI(const std::string& osNarrowPath);

--- a/PumaRhino/utils.h
+++ b/PumaRhino/utils.h
@@ -93,11 +93,11 @@ struct ShapeAttributes {
 	std::wstring startRule;
 	std::wstring shapeName;
 	RuleFileInfoPtr ruleFileInfo;
-	int seed;
+	int32_t seed;
 
 	ShapeAttributes(RuleFileInfoPtr ruleFileInfo, const std::wstring rulef = L"bin/rule.cgb",
 	                const std::wstring startRl = L"Default$Lot", const std::wstring shapeN = L"Lot",
-	                const int seed = 0);
+	                const int32_t seed = 0);
 };
 
 AttributeMapPtr createAttributeMapForShape(const ShapeAttributes& attrs, prt::AttributeMapBuilder& bld);

--- a/PumaRhino/utils.h
+++ b/PumaRhino/utils.h
@@ -167,8 +167,8 @@ void fillArrayMapBuilder(const std::wstring& /* key */, const std::vector<const 
 }
 
 template <>
-inline void fillMapBuilder<int>(const std::wstring& key, int value, AttributeMapBuilderPtr& aBuilder) {
-	aBuilder->setBool(key.c_str(), static_cast<bool>(value));
+inline void fillMapBuilder<bool>(const std::wstring& key, bool value, AttributeMapBuilderPtr& aBuilder) {
+	aBuilder->setBool(key.c_str(), value);
 }
 
 template <>

--- a/PumaRhino/utils.h
+++ b/PumaRhino/utils.h
@@ -155,20 +155,25 @@ const std::wstring toCeArray(const int* values, size_t count);
 
 template<typename T>
 void fillMapBuilder(const std::wstring& /* key */, T /* value */, AttributeMapBuilderPtr& /* aBuilder */) {
-	static_assert(std::is_same<T, int>::value || std::is_same<T, double>::value || std::is_same<T, bool>::value,
-	              "Type T must be one of int, double or bool");
+	static_assert(std::is_same<T, int32_t>::value || std::is_same<T, double>::value || std::is_same<T, bool>::value,
+	              "Type T must be one of int32_t, double or bool");
 }
 
 template<typename T>
 void fillArrayMapBuilder(const std::wstring& /* key */, const std::vector<const wchar_t*>& /* values */,
 	AttributeMapBuilderPtr& /* aBuilder */) {
-	static_assert(std::is_same<T, int>::value || std::is_same<T, double>::value || std::is_same<T, bool>::value,
-	              "Type T must be one of int, double or bool");
+	static_assert(std::is_same<T, int32_t>::value || std::is_same<T, double>::value || std::is_same<T, bool>::value,
+	              "Type T must be one of int32_t, double or bool");
 }
 
 template <>
 inline void fillMapBuilder<bool>(const std::wstring& key, bool value, AttributeMapBuilderPtr& aBuilder) {
 	aBuilder->setBool(key.c_str(), value);
+}
+
+template <>
+inline void fillMapBuilder<int32_t>(const std::wstring& key, int32_t value, AttributeMapBuilderPtr& aBuilder) {
+	aBuilder->setInt(key.c_str(), value);
 }
 
 template <>
@@ -187,6 +192,16 @@ inline void fillArrayMapBuilder<bool>(const std::wstring& key, const std::vector
 }
 
 template <>
+inline void fillArrayMapBuilder<int32_t>(const std::wstring& key, const std::vector<const wchar_t*>& values,
+                                     AttributeMapBuilderPtr& aBuilder) {
+	int32_t* iArray = new int32_t[values.size()];
+	for (int i = 0; i < values.size(); ++i) {
+		iArray[i] = (int32_t)std::stoi(std::wstring(values[i]));
+	}
+	aBuilder->setIntArray(key.c_str(), iArray, values.size());
+}
+
+template <>
 inline void fillArrayMapBuilder<double>(const std::wstring& key, const std::vector<const wchar_t*>& values,
                                  AttributeMapBuilderPtr& aBuilder) {
 	double* dArray = new double[values.size()];
@@ -200,6 +215,9 @@ inline void fillArrayMapBuilder<double>(const std::wstring& key, const std::vect
 void unpackBoolAttributes(int start, int count, ON_ClassArray<ON_wString>* keys, ON_SimpleArray<int>* values,
                       AttributeMapBuilderPtr& aBuilder);
 
+void unpackIntegerAttributes(int start, int count, ON_ClassArray<ON_wString>* keys, ON_SimpleArray<int>* values,
+                             AttributeMapBuilderPtr& aBuilder);
+
 void unpackDoubleAttributes(int start, int count, ON_ClassArray<ON_wString>* keys, ON_SimpleArray<double>* values,
                           AttributeMapBuilderPtr& aBuilder);
 
@@ -208,6 +226,9 @@ void unpackDoubleArrayAttributes(int start, int count, ON_ClassArray<ON_wString>
 
 void unpackBoolArrayAttributes(int start, int count, ON_ClassArray<ON_wString>* keys, ON_ClassArray<ON_wString>* values,
                            AttributeMapBuilderPtr& aBuilder);
+
+void unpackIntegerArrayAttributes(int start, int count, ON_ClassArray<ON_wString>* keys,
+                                  ON_ClassArray<ON_wString>* values, AttributeMapBuilderPtr& aBuilder);
 
 void unpackStringAttributes(int start, int count, ON_ClassArray<ON_wString>* keys, ON_ClassArray<ON_wString>* values,
                             AttributeMapBuilderPtr& aBuilder, bool isArray);


### PR DESCRIPTION
JIRA: https://zrh-jira.esri.com/browse/CE-8392

This PR fixes the bugs found by Ricardo when reviewing the latest stateless prt changes and CI improvements.

Modifications:

- The seed value was never set because the function `extractMainShapeAttributes` was checking for an integer, where the seed was given as a `Double` number.
- Boolean attributes were not working anymore because the function filling the attributes was trying to call the `fillMapBuilder` specialization for `boolean`, which was not existing.
- Transparency was broken because the double opacity value was added to an int buffer, thus the final value was either 1 or 0.
- Additional change: I added the disposal of the array attribute buffers.

I tested with the Street Segment Scene and the reported issues seem to be gone.