### PR TITLE
Fix build failure

### DIFF
--- a/create_package.py
+++ b/create_package.py
@@ -8,7 +8,7 @@ from string import Template
 
 PACKAGE_WHITELIST = ["PumaGrasshopper.gha", "PumaRhino.rhp", "com.esri.prt.core.dll", "glutess.dll",
                      "lib/PumaCodecs.dll", "lib/com.esri.prt.adaptors.dll", "lib/com.esri.prt.codecs.dll",
-                     "lib/com.esri.prt.usd.dll", "lib/usd_ms.dll", "lib/tbb.dll", "lib/usd",
+                     "lib/com.esri.prt.usd.dll", "lib/prt_usd_ms.dll", "lib/prt_tbb.dll", "lib/usd",
                      "lib/com.esri.prt.oda.dll"]
 
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 name: Puma
-version: 1.6.0
+version: 1.1.0
 authors:
   - Esri RnD Center Zurich
 description: >


### PR DESCRIPTION
This PR fixes the build issues that were caused by DLLs having the old names. 

I also did put back the version number to 1.1.0.