### PR TITLE
Extract parameter: correctly handle attributes without group

### DIFF
--- a/PumaGrasshopper/AttributeParameter.cs
+++ b/PumaGrasshopper/AttributeParameter.cs
@@ -46,7 +46,7 @@ namespace PumaGrasshopper.AttributeParameter
 
         public PumaParameter(string groupName, bool expectsArray, List<Annotations.Base> annotations) : base("PumaParam", "PumaParam", "Default puma parameter", ComponentLibraryInfo.MainCategory, ComponentLibraryInfo.PumaSubCategory)
         {
-            mGroupName = groupName;
+            mGroupName = groupName != null ? groupName : "";
             mExpectsArray = expectsArray;
             mAnnotations = annotations;
         }


### PR DESCRIPTION
Ensure internal contract that no group means mGroupName == empty string (not null)