### PR TITLE
Bulk input component

### DIFF
--- a/PumaGrasshopper/ComponentPuma.cs
+++ b/PumaGrasshopper/ComponentPuma.cs
@@ -40,6 +40,8 @@ namespace PumaGrasshopper
 
     public class ComponentPuma : ComponentPumaShared, IGH_VariableParameterComponent
     {
+        public const string COMPONENT_NAME = "Puma";
+        public const string COMPONENT_NICK_NAME = "CityEngine Puma";
 
         enum InputParams
         {

--- a/PumaGrasshopper/ComponentPuma.cs
+++ b/PumaGrasshopper/ComponentPuma.cs
@@ -34,62 +34,12 @@ using Rhino.Runtime.InteropWrappers;
 using System.IO;
 using GH_IO.Serialization;
 
+
 namespace PumaGrasshopper
 {
 
-    public class ComponentPuma : GH_Component, IGH_VariableParameterComponent
+    public class ComponentPuma : ComponentPumaShared, IGH_VariableParameterComponent
     {
-        const string COMPONENT_NAME = "Puma";
-        const string COMPONENT_NICK_NAME = "CityEngine Puma";
-
-        const string RPK_INPUT_NAME = "Path to Rule Package";
-        const string RPK_INPUT_NICK_NAME = "RPK";
-        const string RPK_INPUT_DESC = "Path to a CityEngine rule package (RPK).";
-
-        const string GEOM_INPUT_NAME = "Input Shapes";
-        const string GEOM_INPUT_NICK_NAME = "Shapes";
-        const string GEOM_INPUT_DESC = "Input shapes on which to execute the rules.";
-
-        const string SEED_INPUT_NAME = "Seed";
-        const string SEED_KEY = "seed";
-        const string SEED_INPUT_DESC = "A number that will be used to seed the PRT random number generator.";
-
-        const string GEOM_OUTPUT_NAME = "Generated Models";
-        const string GEOM_OUTPUT_NICK_NAME = "Models";
-        const string GEOM_OUTPUT_DESC = "Generated model geometry per input shape.";
-
-        const string MATERIAL_OUTPUT_NAME = "Materials";
-        const string MATERIAL_OUTPUT_NICK_NAME = "Materials";
-        const string MATERIAL_OUTPUT_DESC = "Material attributes per input shape.";
-
-        const string REPORTS_OUTPUT_NAME = "CGA Reports";
-        const string REPORTS_OUTPUT_NICK_NAME = "Reports";
-        const string REPORTS_OUTPUT_DESC = "CGA report values per input shape.";
-
-        const string CGA_PRINT_OUTPUT_NAME = "CGA Print Output";
-        const string CGA_PRINT_OUTPUT_NICK_NAME = "Prints";
-        const string CGA_PRINT_OUTPUT_DESC = "CGA print output per input shape.";
-
-        const string CGA_ERROR_OUTPUT_NAME = "CGA and Asset Errors";
-        const string CGA_ERROR_OUTPUT_NICK_NAME = "Errors";
-        const string CGA_ERROR_OUTPUT_DESC = "CGA and asset errors encountered per input shape.";
-
-        const string CITYENGINE_RESOURCES_URL = "https://doc.arcgis.com/en/cityengine";
-        enum ParamType
-        {
-            GEOMETRY,
-            FILEPATH,
-            INTEGER,
-            GENERIC
-        }
-
-        struct ParameterDescriptor
-        {
-            public ParamType type;
-            public string name;
-            public string nickName;
-            public string desc;
-        }
 
         enum InputParams
         {
@@ -104,65 +54,8 @@ namespace PumaGrasshopper
             new ParameterDescriptor{ type = ParamType.INTEGER, name = SEED_KEY, nickName = SEED_INPUT_NAME, desc = SEED_INPUT_DESC },
         };
 
-        enum OutputParams
-        {
-            MODELS,
-            MATERIALS,
-            REPORTS,
-            PRINTS,
-            ERRORS
-        }
-
-        static readonly ParameterDescriptor[] OUTPUT_PARAM_DESC = new ParameterDescriptor[]{
-            new ParameterDescriptor{ type = ParamType.GEOMETRY, name = GEOM_OUTPUT_NAME, nickName = GEOM_OUTPUT_NICK_NAME, desc = GEOM_OUTPUT_DESC },
-            new ParameterDescriptor{ type = ParamType.GENERIC, name = MATERIAL_OUTPUT_NAME, nickName = MATERIAL_OUTPUT_NICK_NAME, desc = MATERIAL_OUTPUT_DESC },
-            new ParameterDescriptor{ type = ParamType.GENERIC, name = REPORTS_OUTPUT_NAME, nickName = REPORTS_OUTPUT_NICK_NAME, desc = REPORTS_OUTPUT_DESC },
-            new ParameterDescriptor{ type = ParamType.GENERIC, name = CGA_PRINT_OUTPUT_NAME, nickName = CGA_PRINT_OUTPUT_NICK_NAME, desc = CGA_PRINT_OUTPUT_DESC },
-            new ParameterDescriptor{ type = ParamType.GENERIC, name = CGA_ERROR_OUTPUT_NAME, nickName = CGA_ERROR_OUTPUT_NICK_NAME, desc = CGA_ERROR_OUTPUT_DESC },
-        };
-
-        RulePackage mCurrentRpk;
-
-        /// Stores the optional input parameters
-        RuleAttribute[] mRuleAttributes;
-
-        AttributesValuesMap[] mDefaultValues;
-
-        bool mDoGenerateMaterials;
-
-        public class RulePackage
-        {
-            public string path { get; set; }
-            public DateTime timestamp { get; set; }
-            
-            public bool IsValid()
-            {
-                return (path != null) && (path.Length > 0) && (timestamp != null);
-            }
-
-            public bool IsSame(RulePackage other)
-            {
-                if (path == null || other.path == null)
-                    return false; // default-initialized rule package paths are always different
-                return (string.Compare(path, other.path) == 0) && (timestamp == other.timestamp);
-            }
-        };
-
         public ComponentPuma()
-          : base(COMPONENT_NAME, COMPONENT_NICK_NAME,
-              "Puma runs CityEngine CGA rules on input shapes and returns the generated models. (Version " + PRTWrapper.GetVersion() + ")",
-              ComponentLibraryInfo.MainCategory, ComponentLibraryInfo.PumaSubCategory)
-        {
-            // Initialize PRT engine
-            bool status = PRTWrapper.InitializeRhinoPRT();
-            if (!status) throw new Exception("Fatal Error: PRT initialization failed.");
-
-            mRuleAttributes = new RuleAttribute[0];
-
-            mDoGenerateMaterials = true;
-
-            mCurrentRpk = null;
-        }
+          : base(COMPONENT_NAME, COMPONENT_NICK_NAME) { }
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
@@ -179,23 +72,6 @@ namespace PumaGrasshopper
                         break;
                     case ParamType.INTEGER:
                         pManager.AddIntegerParameter(desc.name, desc.nickName, desc.desc, GH_ParamAccess.tree, 0);
-                        break;
-                }
-            }
-        }
-
-        protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
-        {
-            foreach (var param in Enum.GetValues(typeof(OutputParams)).Cast<OutputParams>())
-            {
-                var desc = OUTPUT_PARAM_DESC[(int)param];
-                switch (desc.type)
-                {
-                    case ParamType.GEOMETRY:
-                        pManager.AddGeometryParameter(desc.name, desc.nickName, desc.desc, GH_ParamAccess.tree);
-                        break;
-                    case ParamType.GENERIC:
-                        pManager.AddGenericParameter(desc.name, desc.nickName, desc.desc, GH_ParamAccess.tree);
                         break;
                 }
             }
@@ -230,52 +106,6 @@ namespace PumaGrasshopper
             OutputCGAErrors(DA, generatedMeshes.errors);
         }
 
-        private RulePackage GetRulePackage(IGH_DataAccess dataAccess)
-        {
-            var result = new RulePackage();
-            
-            string rpkPath = "";
-            if (!dataAccess.GetData(RPK_INPUT_NAME, ref rpkPath))
-                return result;
-
-            try
-            {
-                result.path = RulePackageParam.GetAbsoluteRulePackagePath(OnPingDocument(), rpkPath);
-
-                FileInfo fi = new FileInfo(result.path);
-                result.timestamp = fi.LastWriteTime;
-            }
-            catch (Exception e)
-            {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Unable to compute absolute path to RPK: " + e.Message);
-            }
-
-
-            return result;
-        }
-
-        private List<Mesh> CreateInputMeshes(IGH_DataAccess dataAccess)
-        {
-            if (!dataAccess.GetDataTree<IGH_GeometricGoo>(GEOM_INPUT_NAME, out GH_Structure<IGH_GeometricGoo> inputShapes))
-                return null;
-
-            var meshes = new List<Mesh>();
-
-            int initShapeIdx = 0;
-            foreach (IGH_GeometricGoo geom in inputShapes.AllData(true))
-            {
-                Mesh mesh = ConvertToMesh(geom);
-                if (mesh != null)
-                {
-                    mesh.SetUserString(PRTWrapper.INIT_SHAPE_IDX_KEY, initShapeIdx.ToString());
-                    meshes.Add(mesh);
-                }
-                initShapeIdx++;
-            }
-
-            return meshes;
-        }
-
         private RuleAttributesMap FillAttributesFromNode(IGH_DataAccess DA, int shapeCount)
         {
             RuleAttributesMap MM = new RuleAttributesMap();
@@ -299,115 +129,6 @@ namespace PumaGrasshopper
             }
 
             return MM;
-        }
-
-        protected override void AppendAdditionalComponentMenuItems(ToolStripDropDown menu)
-        {
-            base.AppendAdditionalComponentMenuItems(menu);
-
-            Menu_AppendItem(menu, "Generate Materials", OnMaterialToggleClicked, true, mDoGenerateMaterials);
-            Menu_AppendSeparator(menu);
-            Menu_AppendItem(menu, "Go to CityEngine Resources", (object sender, EventArgs e) => { Process.Start(CITYENGINE_RESOURCES_URL); });
-        }
-
-        private void OnMaterialToggleClicked(object sender, EventArgs e)
-        {
-            mDoGenerateMaterials = !mDoGenerateMaterials;
-            PRTWrapper.SetMaterialGenerationOption(mDoGenerateMaterials);
-
-            ExpireSolution(true);
-        }
-
-        private void OutputGeometry(IGH_DataAccess dataAccess, List<Mesh[]> generatedMeshes)
-        {
-            var meshStructure = Utils.CreateMeshStructure(generatedMeshes);
-            dataAccess.SetDataTree((int)OutputParams.MODELS, meshStructure);
-        }
-
-        private void OutputMaterials(IGH_DataAccess dataAccess, List<GH_Material[]> generatedMaterials)
-        {
-            if (!mDoGenerateMaterials)
-                return;
-
-            GH_Structure<GH_Material> materials = Utils.CreateMaterialStructure(generatedMaterials);
-            dataAccess.SetDataTree((int)OutputParams.MATERIALS, materials);
-        }
-
-        private void OutputReports(IGH_DataAccess dataAccess, List<ReportAttribute[]> generatedReports)
-        {
-            GH_Structure<ReportAttribute> reports = new GH_Structure<ReportAttribute>();
-
-            for (int shapeId = 0; shapeId < generatedReports.Count; shapeId++)
-            {
-                
-                if (generatedReports[shapeId].Length > 0)
-                {
-                    GH_Path path = new GH_Path(shapeId);
-                    reports.AppendRange(generatedReports[shapeId], path);
-                }
-            }
-
-            dataAccess.SetDataTree((int)OutputParams.REPORTS, reports);
-        }
-
-        private void OutputCGAPrint(IGH_DataAccess dataAccess, List<GH_String[]> generatedPrints)
-        {
-            var outputTree = new GH_Structure<GH_String>();
-
-            for (int shapeId = 0; shapeId < generatedPrints.Count; shapeId++)
-            {
-                var shapePath = new GH_Path(shapeId);
-
-
-                outputTree.AppendRange(generatedPrints[shapeId], shapePath);
-            }
-
-            dataAccess.SetDataTree((int)OutputParams.PRINTS, outputTree);
-        }
-
-        private void OutputCGAErrors(IGH_DataAccess dataAccess, List<GH_String[]> generatedErrors)
-        {
-            var outputTree = new GH_Structure<GH_String>();
-
-            for (int shapeId = 0; shapeId < generatedErrors.Count; shapeId++)
-            {
-                var shapePath = new GH_Path(shapeId);
-                outputTree.AppendRange(generatedErrors[shapeId], shapePath);
-            }
-
-            dataAccess.SetDataTree((int)OutputParams.ERRORS, outputTree);
-        }
-
-        private Mesh ConvertToMesh(IGH_GeometricGoo shape)
-        {
-            Mesh mesh = null;
-
-            if (shape is GH_Brep)
-            {
-                Brep brepShape = null;
-                if (!GH_Convert.ToBrep(shape, ref brepShape, GH_Conversion.Both))
-                    return null;
-
-                mesh = new Mesh();
-                mesh.Append(Mesh.CreateFromBrep(brepShape, MeshingParameters.FastRenderMesh));
-                mesh.Compact();
-            }
-            else if (shape is GH_Surface)
-            {
-                Surface surf = null;
-                if (!GH_Convert.ToSurface(shape, ref surf, GH_Conversion.Both))
-                    return null;
-                mesh = Mesh.CreateFromSurface(surf, MeshingParameters.FastRenderMesh);
-            }
-            else
-            {
-                if (!GH_Convert.ToMesh(shape, ref mesh, GH_Conversion.Both))
-                    return null;
-            }
-
-            mesh.Vertices.UseDoublePrecisionVertices = true;
-
-            return mesh;
         }
 
         private void SetAttributeOfShapes(IGH_DataAccess DA, int shapeCount, int shapeId, IGH_Param attributeParam, bool expectArray, ref RuleAttributesMap MM)

--- a/PumaGrasshopper/ComponentPumaBulkInput.cs
+++ b/PumaGrasshopper/ComponentPumaBulkInput.cs
@@ -1,0 +1,144 @@
+﻿/**
+ * Puma - CityEngine Plugin for Rhinoceros
+ *
+ * See https://esri.github.io/cityengine/puma for documentation.
+ *
+ * Copyright (c) 2021-2023 Esri R&D Center Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Data;
+using Grasshopper.Kernel.Parameters;
+using Grasshopper.Kernel.Types;
+using PumaGrasshopper.Properties;
+using Rhino.Geometry;
+
+namespace PumaGrasshopper
+{
+    
+    public class ComponentPumaBulkInput : ComponentPumaShared
+    {
+        const string BULK_INPUT_NAME = "Rule attributes";
+        const string BULK_INPUT_NICK_NAME = "Attributes";
+        const string BULK_INPUT_DESC = "Attributes passed to the rule. Expects a tree of key:value pairs.";
+        enum InputParams
+        {
+            RPK,
+            SHAPES,
+            SEEDS,
+            BULK,
+        }
+
+        static readonly ParameterDescriptor[] INPUT_PARAM_DESC = new ParameterDescriptor[]{
+            new ParameterDescriptor{ type = ParamType.FILEPATH, name = RPK_INPUT_NAME, nickName = RPK_INPUT_NICK_NAME, desc = RPK_INPUT_DESC },
+            new ParameterDescriptor{ type = ParamType.GEOMETRY, name = GEOM_INPUT_NAME, nickName = GEOM_INPUT_NICK_NAME, desc = GEOM_INPUT_DESC },
+            new ParameterDescriptor{ type = ParamType.INTEGER, name = SEED_KEY, nickName = SEED_INPUT_NAME, desc = SEED_INPUT_DESC },
+            new ParameterDescriptor{ type = ParamType.GENERIC, name = BULK_INPUT_NAME, nickName = BULK_INPUT_NICK_NAME, desc = BULK_INPUT_DESC},
+        };
+
+        public ComponentPumaBulkInput()
+          : base(COMPONENT_NAME, COMPONENT_NICK_NAME) { }
+
+        protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
+        {
+            foreach( var param in Enum.GetValues(typeof(InputParams)).Cast<InputParams>())
+            {
+                var desc = INPUT_PARAM_DESC[(int)param];
+                switch (desc.type)
+                {
+                    case ParamType.GEOMETRY:
+                        pManager.AddGeometryParameter(desc.name, desc.nickName, desc.desc, GH_ParamAccess.tree);
+                        break;
+                    case ParamType.FILEPATH:
+                        pManager.AddParameter(new RulePackageParam(), desc.name, desc.nickName, desc.desc, GH_ParamAccess.item);
+                        break;
+                    case ParamType.INTEGER:
+                        pManager.AddIntegerParameter(desc.name, desc.nickName, desc.desc, GH_ParamAccess.tree, 0);
+                        break;
+                    case ParamType.GENERIC:
+                        pManager.AddGenericParameter(desc.name, desc.nickName, desc.desc, GH_ParamAccess.tree);
+                        break;
+                }
+            }
+        }
+
+        protected override void SolveInstance(IGH_DataAccess DA)
+        {
+            ClearRuntimeMessages();
+
+            RulePackage rpk = GetRulePackage(DA);
+            if (!rpk.IsValid())
+                return;
+
+            List<Mesh> inputMeshes = CreateInputMeshes(DA);
+            if (inputMeshes == null || inputMeshes.Count == 0)
+                return;
+
+            if (mCurrentRpk == null || !mCurrentRpk.IsSame(rpk))
+            {
+                mCurrentRpk = rpk;
+                mRuleAttributes = PRTWrapper.GetRuleAttributes(rpk.path);
+            }
+
+            RuleAttributesMap MM = ParseBulkInputTree(DA, inputMeshes.Count);
+
+            var generatedMeshes = PRTWrapper.Generate(rpk.path, ref MM, inputMeshes);
+            OutputGeometry(DA, generatedMeshes.meshes);
+            OutputMaterials(DA, generatedMeshes.materials);
+            OutputReports(DA, generatedMeshes.reports);
+            OutputCGAPrint(DA, generatedMeshes.prints);
+            OutputCGAErrors(DA, generatedMeshes.errors);
+        }
+
+        private RuleAttributesMap ParseBulkInputTree(IGH_DataAccess DA, int shapeCount)
+        {
+            RuleAttributesMap MM = new RuleAttributesMap();
+
+            GH_Structure<GH_Goo<Param_GenericObject>> inputTree;
+            if (!DA.GetDataTree(BULK_INPUT_NAME, out inputTree))
+                return null;
+
+            List<RuleAttribute> attributesList = mRuleAttributes.ToList();
+
+            for(int shapeId = 0; shapeId < shapeCount; ++shapeId)
+            {
+                MM.StartNewSection();
+
+                List<KeyValuePair<string, object>> branch = (List<KeyValuePair<string, object>>)inputTree.get_Branch(shapeId);
+
+                branch.ForEach((attribute) => {
+                    // TODO
+                });
+            }
+
+            return MM;
+        }
+
+        protected override System.Drawing.Bitmap Icon
+        {
+            get
+            {
+                return Resources.gh_prt_main_component;
+            }
+        }
+
+        public override Guid ComponentGuid
+        {
+            get { return PumaUIDs.ComponentPumaBulkInputGuid; }
+        }
+    }
+}

--- a/PumaGrasshopper/ComponentPumaBulkInput.cs
+++ b/PumaGrasshopper/ComponentPumaBulkInput.cs
@@ -152,9 +152,6 @@ namespace PumaGrasshopper
                         }
                     });
                 }
-
-                
-                
             }
 
             return MM;

--- a/PumaGrasshopper/ComponentPumaBulkInput.cs
+++ b/PumaGrasshopper/ComponentPumaBulkInput.cs
@@ -119,16 +119,17 @@ namespace PumaGrasshopper
             {
                 MM.StartNewSection();
 
-                if(shapeId < inputTree.PathCount)
-                {
-                    List<IGH_Goo> branch = (List<IGH_Goo>)inputTree.get_Branch(shapeId);
+                // Repeat the last attribute branch in case there is more shape than attribute branch.
+                var branchId = shapeId < inputTree.PathCount ? shapeId : inputTree.PathCount - 1;
 
-                    branch.ForEach((input) => {
-                        var pair = Utils.ParseInputPair(input);
-                        var attribute = attributesList.Find(attr => attr.mFullName.Equals(pair.Key) || attr.mNickname.Equals(pair.Key));
+                List<IGH_Goo> branch = (List<IGH_Goo>)inputTree.get_Branch(branchId);
 
-                        if (attribute == null) return;
+                branch.ForEach((input) => {
+                    var pair = Utils.ParseInputPair(input);
+                    var attribute = attributesList.Find(attr => attr.mFullName.Equals(pair.Key) || attr.mNickname.Equals(pair.Key));
 
+                    if(attribute != null)
+                    {
                         if (attribute.IsArray())
                         {
                             SetRuleAttributeArray(attribute, pair.Value, ref MM);
@@ -140,8 +141,9 @@ namespace PumaGrasshopper
                         {
                             throw new Exception("Attribute key " + pair.Key + " has no corresponding value");
                         }
-                    });
-                } 
+                    }
+                });
+                
             }
 
             return MM;

--- a/PumaGrasshopper/ComponentPumaBulkInput.cs
+++ b/PumaGrasshopper/ComponentPumaBulkInput.cs
@@ -22,7 +22,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Data;
-using Grasshopper.Kernel.Parameters;
 using Grasshopper.Kernel.Types;
 using PumaGrasshopper.Properties;
 using Rhino.Geometry;
@@ -145,7 +144,8 @@ namespace PumaGrasshopper
                             else if(pair.Value.Length > 0)
                             {
                                 SetRuleAttribute(attribute, pair.Value[0], ref MM);
-                            } else
+                            } 
+                            else
                             {
                                 throw new Exception("Attribute key " + pair.Key + " has no corresponding value");
                             }

--- a/PumaGrasshopper/ComponentPumaBulkInput.cs
+++ b/PumaGrasshopper/ComponentPumaBulkInput.cs
@@ -197,12 +197,7 @@ namespace PumaGrasshopper
             {
                 case Annotations.AnnotationArgumentType.AAT_BOOL_ARRAY:
                     try { 
-                        bool[] boolList = Array.ConvertAll<object, bool>((object[])value, (x) =>
-                        {
-                            if (x is bool || x is int) return (bool)x;
-                            if (x is string) return Boolean.Parse((string)x);
-                            return false;
-                        });
+                        bool[] boolList = Array.ConvertAll(value, (x) => Convert.ToBoolean(x));
                         MM.AddBoolArray(name, boolList);
                     } catch(Exception)
                     {
@@ -211,21 +206,25 @@ namespace PumaGrasshopper
                     break;
                 case Annotations.AnnotationArgumentType.AAT_FLOAT_ARRAY:
                     try {
-                        double[] doubleList = Array.ConvertAll<object, double>((object[])value, (x) =>
-                        {
-                            if (x is float || x is double) return (double)x;
-                            if (x is string) return Double.Parse((string)x);
-                            return 0;
-                        });
+                        double[] doubleList = Array.ConvertAll(value, (x) => Convert.ToDouble(x));
                         MM.AddDoubleArray(name, doubleList);
                     } catch(Exception)  {
                         throw new Exception(Utils.GetCastErrorMessage(name, "double array"));
                     }
                     break;
                 case Annotations.AnnotationArgumentType.AAT_STR_ARRAY:
-                    // TODO
+                    MM.AddStringArray(name, value);
+                    break;
                 case Annotations.AnnotationArgumentType.AAT_INT_ARRAY:
-                    // TODO
+                    try
+                    {
+                        int[] intList = Array.ConvertAll(value, x => Convert.ToInt32(x));
+                        MM.AddIntegerArray(name, intList);
+                    } catch(Exception)
+                    {
+                        throw new Exception(Utils.GetCastErrorMessage(name, "integer array"));
+                    }
+                    break;
                 default:
                     return;
             }

--- a/PumaGrasshopper/ComponentPumaShared.cs
+++ b/PumaGrasshopper/ComponentPumaShared.cs
@@ -32,9 +32,6 @@ namespace PumaGrasshopper
 {
     public abstract class ComponentPumaShared: GH_Component
     {
-        public const string COMPONENT_NAME = "Puma";
-        public const string COMPONENT_NICK_NAME = "CityEngine Puma";
-
         public const string RPK_INPUT_NAME = "Path to Rule Package";
         public const string RPK_INPUT_NICK_NAME = "RPK";
         public const string RPK_INPUT_DESC = "Path to a CityEngine rule package (RPK).";

--- a/PumaGrasshopper/ComponentPumaShared.cs
+++ b/PumaGrasshopper/ComponentPumaShared.cs
@@ -141,7 +141,6 @@ namespace PumaGrasshopper
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Unable to compute absolute path to RPK: " + e.Message);
             }
 
-
             return result;
         }
 
@@ -276,8 +275,6 @@ namespace PumaGrasshopper
             for (int shapeId = 0; shapeId < generatedPrints.Count; shapeId++)
             {
                 var shapePath = new GH_Path(shapeId);
-
-
                 outputTree.AppendRange(generatedPrints[shapeId], shapePath);
             }
 
@@ -296,6 +293,5 @@ namespace PumaGrasshopper
 
             dataAccess.SetDataTree((int)OutputParams.ERRORS, outputTree);
         }
-
     }
 }

--- a/PumaGrasshopper/ComponentPumaShared.cs
+++ b/PumaGrasshopper/ComponentPumaShared.cs
@@ -1,0 +1,304 @@
+﻿/**
+ * Puma - CityEngine Plugin for Rhinoceros
+ *
+ * See https://esri.github.io/cityengine/puma for documentation.
+ *
+ * Copyright (c) 2021-2023 Esri R&D Center Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Data;
+using Grasshopper.Kernel.Types;
+using Rhino.Geometry;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace PumaGrasshopper
+{
+    public abstract class ComponentPumaShared: GH_Component
+    {
+        public const string COMPONENT_NAME = "Puma";
+        public const string COMPONENT_NICK_NAME = "CityEngine Puma";
+
+        public const string RPK_INPUT_NAME = "Path to Rule Package";
+        public const string RPK_INPUT_NICK_NAME = "RPK";
+        public const string RPK_INPUT_DESC = "Path to a CityEngine rule package (RPK).";
+
+        public const string GEOM_INPUT_NAME = "Input Shapes";
+        public const string GEOM_INPUT_NICK_NAME = "Shapes";
+        public const string GEOM_INPUT_DESC = "Input shapes on which to execute the rules.";
+
+        public const string SEED_INPUT_NAME = "Seed";
+        public const string SEED_KEY = "seed";
+        public const string SEED_INPUT_DESC = "A number that will be used to seed the PRT random number generator.";
+
+        public const string GEOM_OUTPUT_NAME = "Generated Models";
+        public const string GEOM_OUTPUT_NICK_NAME = "Models";
+        public const string GEOM_OUTPUT_DESC = "Generated model geometry per input shape.";
+
+        public const string MATERIAL_OUTPUT_NAME = "Materials";
+        public const string MATERIAL_OUTPUT_NICK_NAME = "Materials";
+        public const string MATERIAL_OUTPUT_DESC = "Material attributes per input shape.";
+
+        public const string REPORTS_OUTPUT_NAME = "CGA Reports";
+        public const string REPORTS_OUTPUT_NICK_NAME = "Reports";
+        public const string REPORTS_OUTPUT_DESC = "CGA report values per input shape.";
+
+        public const string CGA_PRINT_OUTPUT_NAME = "CGA Print Output";
+        public const string CGA_PRINT_OUTPUT_NICK_NAME = "Prints";
+        public const string CGA_PRINT_OUTPUT_DESC = "CGA print output per input shape.";
+
+        public const string CGA_ERROR_OUTPUT_NAME = "CGA and Asset Errors";
+        public const string CGA_ERROR_OUTPUT_NICK_NAME = "Errors";
+        public const string CGA_ERROR_OUTPUT_DESC = "CGA and asset errors encountered per input shape.";
+
+        public const string CITYENGINE_RESOURCES_URL = "https://doc.arcgis.com/en/cityengine";
+
+        public enum ParamType
+        {
+            GEOMETRY,
+            FILEPATH,
+            INTEGER,
+            GENERIC
+        }
+
+        public struct ParameterDescriptor
+        {
+            public ParamType type;
+            public string name;
+            public string nickName;
+            public string desc;
+        }
+
+        public enum OutputParams
+        {
+            MODELS,
+            MATERIALS,
+            REPORTS,
+            PRINTS,
+            ERRORS
+        }
+
+        public static readonly ParameterDescriptor[] OUTPUT_PARAM_DESC = new ParameterDescriptor[]{
+            new ParameterDescriptor{ type = ParamType.GEOMETRY, name = GEOM_OUTPUT_NAME, nickName = GEOM_OUTPUT_NICK_NAME, desc = GEOM_OUTPUT_DESC },
+            new ParameterDescriptor{ type = ParamType.GENERIC, name = MATERIAL_OUTPUT_NAME, nickName = MATERIAL_OUTPUT_NICK_NAME, desc = MATERIAL_OUTPUT_DESC },
+            new ParameterDescriptor{ type = ParamType.GENERIC, name = REPORTS_OUTPUT_NAME, nickName = REPORTS_OUTPUT_NICK_NAME, desc = REPORTS_OUTPUT_DESC },
+            new ParameterDescriptor{ type = ParamType.GENERIC, name = CGA_PRINT_OUTPUT_NAME, nickName = CGA_PRINT_OUTPUT_NICK_NAME, desc = CGA_PRINT_OUTPUT_DESC },
+            new ParameterDescriptor{ type = ParamType.GENERIC, name = CGA_ERROR_OUTPUT_NAME, nickName = CGA_ERROR_OUTPUT_NICK_NAME, desc = CGA_ERROR_OUTPUT_DESC },
+        };
+
+        protected RulePackage mCurrentRpk;
+
+        /// Stores the optional input parameters
+        protected RuleAttribute[] mRuleAttributes;
+
+        protected AttributesValuesMap[] mDefaultValues;
+
+        protected bool mDoGenerateMaterials;
+
+        public ComponentPumaShared(string name, string nickname): base(name, nickname, "Puma runs CityEngine CGA rules on input shapes and returns the generated models. (Version " + PRTWrapper.GetVersion() + ")",
+            ComponentLibraryInfo.MainCategory, ComponentLibraryInfo.PumaSubCategory)
+        {
+            bool status = PRTWrapper.InitializeRhinoPRT();
+            if (!status) throw new Exception("Fatal Error: PRT initialization failed.");
+
+            mRuleAttributes = new RuleAttribute[0];
+
+            mDoGenerateMaterials = true;
+
+            mCurrentRpk = null;
+        }
+
+        protected RulePackage GetRulePackage(IGH_DataAccess dataAccess)
+        {
+            var result = new RulePackage();
+
+            string rpkPath = "";
+            if (!dataAccess.GetData(RPK_INPUT_NAME, ref rpkPath))
+                return result;
+
+            try
+            {
+                result.path = RulePackageParam.GetAbsoluteRulePackagePath(OnPingDocument(), rpkPath);
+
+                FileInfo fi = new FileInfo(result.path);
+                result.timestamp = fi.LastWriteTime;
+            }
+            catch (Exception e)
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Unable to compute absolute path to RPK: " + e.Message);
+            }
+
+
+            return result;
+        }
+
+        protected abstract override void RegisterInputParams(GH_InputParamManager pManager);
+
+        /// <summary>
+        /// Registers all the output parameters for this component.
+        /// </summary>
+        protected override void RegisterOutputParams(GH_OutputParamManager pManager)
+        {
+            foreach (var param in Enum.GetValues(typeof(OutputParams)).Cast<OutputParams>())
+            {
+                var desc = OUTPUT_PARAM_DESC[(int)param];
+                switch (desc.type)
+                {
+                    case ParamType.GEOMETRY:
+                        pManager.AddGeometryParameter(desc.name, desc.nickName, desc.desc, GH_ParamAccess.tree);
+                        break;
+                    case ParamType.GENERIC:
+                        pManager.AddGenericParameter(desc.name, desc.nickName, desc.desc, GH_ParamAccess.tree);
+                        break;
+                }
+            }
+        }
+
+        protected List<Mesh> CreateInputMeshes(IGH_DataAccess dataAccess)
+        {
+            if (!dataAccess.GetDataTree<IGH_GeometricGoo>(GEOM_INPUT_NAME, out GH_Structure<IGH_GeometricGoo> inputShapes))
+                return null;
+
+            var meshes = new List<Mesh>();
+
+            int initShapeIdx = 0;
+            foreach (IGH_GeometricGoo geom in inputShapes.AllData(true))
+            {
+                Mesh mesh = ConvertToMesh(geom);
+                if (mesh != null)
+                {
+                    mesh.SetUserString(PRTWrapper.INIT_SHAPE_IDX_KEY, initShapeIdx.ToString());
+                    meshes.Add(mesh);
+                }
+                initShapeIdx++;
+            }
+
+            return meshes;
+        }
+
+        private Mesh ConvertToMesh(IGH_GeometricGoo shape)
+        {
+            Mesh mesh = null;
+
+            if (shape is GH_Brep)
+            {
+                Brep brepShape = null;
+                if (!GH_Convert.ToBrep(shape, ref brepShape, GH_Conversion.Both))
+                    return null;
+
+                mesh = new Mesh();
+                mesh.Append(Mesh.CreateFromBrep(brepShape, MeshingParameters.FastRenderMesh));
+                mesh.Compact();
+            }
+            else if (shape is GH_Surface)
+            {
+                Surface surf = null;
+                if (!GH_Convert.ToSurface(shape, ref surf, GH_Conversion.Both))
+                    return null;
+                mesh = Mesh.CreateFromSurface(surf, MeshingParameters.FastRenderMesh);
+            }
+            else
+            {
+                if (!GH_Convert.ToMesh(shape, ref mesh, GH_Conversion.Both))
+                    return null;
+            }
+
+            mesh.Vertices.UseDoublePrecisionVertices = true;
+
+            return mesh;
+        }
+
+        protected override void AppendAdditionalComponentMenuItems(ToolStripDropDown menu)
+        {
+            base.AppendAdditionalComponentMenuItems(menu);
+
+            Menu_AppendItem(menu, "Generate Materials", OnMaterialToggleClicked, true, mDoGenerateMaterials);
+            Menu_AppendSeparator(menu);
+            Menu_AppendItem(menu, "Go to CityEngine Resources", (object sender, EventArgs e) => { Process.Start(CITYENGINE_RESOURCES_URL); });
+        }
+
+        private void OnMaterialToggleClicked(object sender, EventArgs e)
+        {
+            mDoGenerateMaterials = !mDoGenerateMaterials;
+            PRTWrapper.SetMaterialGenerationOption(mDoGenerateMaterials);
+
+            ExpireSolution(true);
+        }
+
+        protected void OutputGeometry(IGH_DataAccess dataAccess, List<Mesh[]> generatedMeshes)
+        {
+            var meshStructure = Utils.CreateMeshStructure(generatedMeshes);
+            dataAccess.SetDataTree((int)OutputParams.MODELS, meshStructure);
+        }
+
+        protected void OutputMaterials(IGH_DataAccess dataAccess, List<GH_Material[]> generatedMaterials)
+        {
+            if (!mDoGenerateMaterials)
+                return;
+
+            GH_Structure<GH_Material> materials = Utils.CreateMaterialStructure(generatedMaterials);
+            dataAccess.SetDataTree((int)OutputParams.MATERIALS, materials);
+        }
+
+        protected void OutputReports(IGH_DataAccess dataAccess, List<ReportAttribute[]> generatedReports)
+        {
+            GH_Structure<ReportAttribute> reports = new GH_Structure<ReportAttribute>();
+
+            for (int shapeId = 0; shapeId < generatedReports.Count; shapeId++)
+            {
+                if (generatedReports[shapeId].Length > 0)
+                {
+                    GH_Path path = new GH_Path(shapeId);
+                    reports.AppendRange(generatedReports[shapeId], path);
+                }
+            }
+
+            dataAccess.SetDataTree((int)OutputParams.REPORTS, reports);
+        }
+
+        protected void OutputCGAPrint(IGH_DataAccess dataAccess, List<GH_String[]> generatedPrints)
+        {
+            var outputTree = new GH_Structure<GH_String>();
+
+            for (int shapeId = 0; shapeId < generatedPrints.Count; shapeId++)
+            {
+                var shapePath = new GH_Path(shapeId);
+
+
+                outputTree.AppendRange(generatedPrints[shapeId], shapePath);
+            }
+
+            dataAccess.SetDataTree((int)OutputParams.PRINTS, outputTree);
+        }
+
+        protected void OutputCGAErrors(IGH_DataAccess dataAccess, List<GH_String[]> generatedErrors)
+        {
+            var outputTree = new GH_Structure<GH_String>();
+
+            for (int shapeId = 0; shapeId < generatedErrors.Count; shapeId++)
+            {
+                var shapePath = new GH_Path(shapeId);
+                outputTree.AppendRange(generatedErrors[shapeId], shapePath);
+            }
+
+            dataAccess.SetDataTree((int)OutputParams.ERRORS, outputTree);
+        }
+
+    }
+}

--- a/PumaGrasshopper/PumaGrasshopper.csproj
+++ b/PumaGrasshopper/PumaGrasshopper.csproj
@@ -11,7 +11,7 @@
       <VersionMajor>%(PumaVersions.VERSION_MAJOR)</VersionMajor>
       <VersionMinor>%(PumaVersions.VERSION_MINOR)</VersionMinor>
       <VersionBuild>$(PumaVersionBuild)</VersionBuild>
-	  <VersionBuild Condition="'$(PumaVersionBuild)'==''">%(PumaVersions.VERSION_BUILD)</VersionBuild>
+      <VersionBuild Condition="'$(PumaVersionBuild)'==''">%(PumaVersions.VERSION_BUILD)</VersionBuild>
       <VersionRevision>%(PumaVersions.VERSION_REVISION)</VersionRevision>
     </PropertyGroup>
     <ReadLinesFromFile File=".\Properties\AssemblyVersion.template">
@@ -90,6 +90,7 @@
     <Compile Include="AttributesValuesMap.cs" />
     <Compile Include="ComponentPuma.cs" />
     <Compile Include="ComponentLibraryInfo.cs" />
+    <Compile Include="ComponentPumaBulkInput.cs" />
     <Compile Include="ComponentReportsDisplay.cs" />
     <Compile Include="ComponentReportsUnpacker.cs" />
     <Compile Include="AttributeParameter.cs" />
@@ -99,9 +100,10 @@
     <Compile Include="AttributeForm.Designer.cs">
       <DependentUpon>AttributeForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="ComponentPumaShared.cs" />
     <Compile Include="InteropWrapper.cs" />
     <Compile Include="Properties\AssemblyVersion.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" >
+    <Compile Include="Properties\AssemblyInfo.cs">
       <DependentUpon>Properties\AssemblyVersion.cs</DependentUpon>
     </Compile>
     <Compile Include="Properties\Resources.Designer.cs">
@@ -114,6 +116,7 @@
     <Compile Include="ReportAttribute.cs" />
     <Compile Include="RuleAttribute.cs" />
     <Compile Include="RuleAttributesMap.cs" />
+    <Compile Include="RulePackage.cs" />
     <Compile Include="RulePackageParam.cs" />
     <Compile Include="SerializationIDs.cs" />
     <Compile Include="Utils.cs" />

--- a/PumaGrasshopper/PumaUIDs.cs
+++ b/PumaGrasshopper/PumaUIDs.cs
@@ -28,6 +28,7 @@ namespace PumaGrasshopper
     public static class PumaUIDs
     {
         public static Guid ComponentPumaGuid = new Guid("ad54a111-cdbc-4417-bddd-c2195c9482d8");
+        public static Guid ComponentPumaBulkInputGuid = new Guid("03FB28F9-FF2E-4175-B75B-571E4DC26FE9");
         public static Guid ComponentReportsDislayGuid = new Guid("316524f4-1c56-41e7-9315-10f60b35cd61");
         public static Guid ComponentReportsUnpackerGuid = new Guid("23602a6d-1137-4403-867a-082e001ca707");
 

--- a/PumaGrasshopper/RulePackage.cs
+++ b/PumaGrasshopper/RulePackage.cs
@@ -1,0 +1,41 @@
+﻿/**
+ * Puma - CityEngine Plugin for Rhinoceros
+ *
+ * See https://esri.github.io/cityengine/puma for documentation.
+ *
+ * Copyright (c) 2021-2023 Esri R&D Center Zurich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace PumaGrasshopper
+{
+    public class RulePackage
+    {
+        public string path { get; set; }
+        public DateTime timestamp { get; set; }
+
+        public bool IsValid()
+        {
+            return (path != null) && (path.Length > 0) && (timestamp != null);
+        }
+
+        public bool IsSame(RulePackage other)
+        {
+            if (path == null || other.path == null)
+                return false; // default-initialized rule package paths are always different
+            return (string.Compare(path, other.path) == 0) && (timestamp == other.timestamp);
+        }
+    };
+}

--- a/PumaGrasshopper/Utils.cs
+++ b/PumaGrasshopper/Utils.cs
@@ -323,7 +323,7 @@ namespace PumaGrasshopper
             return "Could not cast attribute " + attribute + " to " + castTarget;
         }
 
-        public static KeyValuePair<string, object> ParseInputPair(IGH_Goo input)
+        public static KeyValuePair<string, string[]> ParseInputPair(IGH_Goo input)
         {
             if (!input.CastTo(out string value)) throw new Exception("Could not cast input pair to string");
 
@@ -331,7 +331,7 @@ namespace PumaGrasshopper
 
             if(tokens.Length >= 2)
             {
-                return new KeyValuePair<string, object>(tokens[0], tokens.Skip(1));
+                return new KeyValuePair<string, string[]>(tokens[0], tokens.Skip(1).ToArray());
             }
             else
             {

--- a/PumaGrasshopper/Utils.cs
+++ b/PumaGrasshopper/Utils.cs
@@ -327,7 +327,7 @@ namespace PumaGrasshopper
         {
             if (!input.CastTo(out string value)) throw new Exception("Could not cast input pair to string");
 
-            string[] tokens = value.Split(':');
+            string[] tokens = StringFromCeArray(value);
 
             if(tokens.Length >= 2)
             {

--- a/PumaGrasshopper/Utils.cs
+++ b/PumaGrasshopper/Utils.cs
@@ -322,5 +322,21 @@ namespace PumaGrasshopper
         {
             return "Could not cast attribute " + attribute + " to " + castTarget;
         }
+
+        public static KeyValuePair<string, object> ParseInputPair(IGH_Goo input)
+        {
+            if (!input.CastTo(out string value)) throw new Exception("Could not cast input pair to string");
+
+            string[] tokens = value.Split(':');
+
+            if(tokens.Length >= 2)
+            {
+                return new KeyValuePair<string, object>(tokens[0], tokens.Skip(1));
+            }
+            else
+            {
+                throw new Exception("Could not cast input pair to string");
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR adds a new Puma component that take a single input for all rule attributes in bulk. This addresses a feature request from one of our early adopters.
![image](https://github.com/Esri/puma/assets/81747273/2746d4d8-c929-494b-b124-9153cb0a9ba4)

The bulk input is expected to be a list of Key:Value pairs. Each branch of the input tree contains the list of Key:Value pair for a single initial shape. The mapping between the attributes and initial shapes is following the usual "Grasshopper way", meaning that the last branch is duplicated in case there is more shapes than bulk input branches. And additional input branches are ignored when there are more than initial shapes.

### Testing

The expected input format for the key-value pairs is: `key:value`. Currently, it is only possible to use a Text or multi-line Note component:
![image](https://github.com/Esri/puma/assets/81747273/b37025f9-57b0-4285-86da-dea0856c9600)
The key can be either the full name or the nickname (i.e. without the "Default$" prefix) of a rule attribute.


### Implementation

- Created a base class for Puma components and moved all common functions and call variables in it. Both components inherit this base class.
- Moved RulePackage class into its own file.
- The new bulk input component has a fixed number of inputs: rpk, shapes, seed and attributes.
- The attribute input expects generic data tree. However, a proper Key:Value object in Grasshopper doesn't seem to exist by default so currently this it only possible to use text inputs.

### Potential improvements

- Rule attribute discovery: Currently it is not practical to know which rule attributes are expected by the rpk. It is needed to use a regular Puma component to browse trough the list of possible rule attributes. I am thinking about adding an "Extract parameter" feature to this component, that creates a text list with all available attributes.
- Key/Value object: Grasshopper doesn't have an object type similar to Dictionaries or key-value pairs by default. We should discuss introducing our own parameter type for this purpose.

