### PR TITLE
Set target windows platform version to latest installed

### DIFF
--- a/PumaCodecs/PumaCodecs.vcxproj
+++ b/PumaCodecs/PumaCodecs.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{80FD5576-DAF6-4922-933D-86EFD7A1DB94}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>codecsrhino</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/PumaCodecs/PumaCodecs.vcxproj
+++ b/PumaCodecs/PumaCodecs.vcxproj
@@ -31,7 +31,7 @@
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <VCToolsVersion>14.3*.*</VCToolsVersion>
+    <VCToolsVersion>14.37.32822</VCToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/PumaCodecs/PumaCodecs.vcxproj
+++ b/PumaCodecs/PumaCodecs.vcxproj
@@ -31,7 +31,7 @@
     <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
-    <VCToolsVersion>14.27.29110</VCToolsVersion>
+    <VCToolsVersion>14.3*.*</VCToolsVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/PumaCodecs/PumaCodecs.vcxproj
+++ b/PumaCodecs/PumaCodecs.vcxproj
@@ -28,7 +28,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <VCToolsVersion>14.27.29110</VCToolsVersion>

--- a/PumaRhino/PumaRhino.vcxproj
+++ b/PumaRhino/PumaRhino.vcxproj
@@ -97,7 +97,7 @@
   <PropertyGroup Label="Globals">
     <Keyword>MFCDLLProj</Keyword>
     <ProjectGuid>{5A60A717-8038-4A31-8045-5C802788F715}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/PumaRhino/PumaRhino.vcxproj
+++ b/PumaRhino/PumaRhino.vcxproj
@@ -111,7 +111,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
     <VCToolsVersion>14.27.29110</VCToolsVersion>

--- a/PumaRhino/PumaRhino.vcxproj
+++ b/PumaRhino/PumaRhino.vcxproj
@@ -114,7 +114,7 @@
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
-    <VCToolsVersion>14.3*.*</VCToolsVersion>
+    <VCToolsVersion>14.37.32822</VCToolsVersion>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/PumaRhino/PumaRhino.vcxproj
+++ b/PumaRhino/PumaRhino.vcxproj
@@ -114,7 +114,7 @@
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>Dynamic</UseOfMfc>
-    <VCToolsVersion>14.27.29110</VCToolsVersion>
+    <VCToolsVersion>14.3*.*</VCToolsVersion>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
Merging the bulk input component PR made the develop build fail. This is caused by a miss match of Windows platform tool-set versions, because we updated the build containers, but on develop we still have the previous versions. 

This PR bumps the versions of Windows SDK, MSVC toolset and Windows platform toolset in both c++ projects to match the ones installed in the docker containers.

Functional review:
- Double check that the build succeeds.